### PR TITLE
Fixed an issue where all playlists would appar blank when starting up

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -493,6 +493,7 @@ PyObject *session_connect(PyObject *self, PyObject *args) {
     config.userdata = (void *)client;
     config.callbacks = &g_callbacks;
     config.user_agent = "unset";
+    config.initially_unload_playlists = 0;
 
 #ifdef DEBUG
     fprintf(stderr, "Config mark 1\n");


### PR DESCRIPTION
Took me quite a while to work out what was going on here.  Theres a new flag that was added to the session config in 0.7 which means playlists would never actually load under pyspotify.  I verified this behaviour with the bundled jukebox app too.

See here for info: https://developer.spotify.com/en/libspotify/docs/structsp__session__config.html#a3460b768cf69d1c646ac39f507e39287.
