### PR TITLE
Exceptions raised in callbacks are written to stderr.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,8 +5,15 @@ Changes
 v1.4 (in development)
 =====================
 
+New features:
+
 - User handling
 - New Playlist method: rename.
+- Exceptions raised in callbacks are written to ``stderr``.
+
+Bug fixes:
+
+- log_message callbacks used ``str`` in place of ``unicode``.
 
 v1.3 (2011-06-11)
 =================

--- a/spotify/manager/container.py
+++ b/spotify/manager/container.py
@@ -2,6 +2,9 @@ class SpotifyContainerManager:
     """
     Handles Spotify playlist container callbacks. To implement you own
     callbacks, inherit from this class.
+
+    Exceptions raised in your callback handlers will be displayed on the
+    standard error output (stderr).
     """
 
     def __init__(self):

--- a/spotify/manager/playlist.py
+++ b/spotify/manager/playlist.py
@@ -2,6 +2,9 @@ class SpotifyPlaylistManager:
     """
     Handles Spotify playlists callbacks. To implement you own callbacks,
     inherit from this class.
+
+    Exceptions raised in your callback handlers will be displayed on the
+    standard error output (stderr).
     """
 
     def __init__(self):

--- a/spotify/manager/session.py
+++ b/spotify/manager/session.py
@@ -6,8 +6,8 @@ class SpotifySessionManager(object):
     Client for Spotify. Inherit from this class to have your callbacks
     called on the appropriate events.
 
-    Exceptions raised in your callback handlers will be silently discarded
-    unless you handle them!
+    Exceptions raised in your callback handlers will be displayed on the
+    standard error output (stderr).
     """
 
     api_version = spotify.api_version

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -246,6 +246,8 @@ playlist_tracks_added_callback(sp_playlist * playlist,
                                        py_tracks,
                                        Py_BuildValue("i", position),
                                        tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_XDECREF(res);
     Py_DECREF(py_tracks);
     Py_DECREF(p);
@@ -282,6 +284,8 @@ playlist_tracks_removed_callback(sp_playlist * playlist, const int *tracks,
     res = PyObject_CallFunctionObjArgs(tramp->callback,
                                        tramp->manager,
                                        p, py_tracks, tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_XDECREF(res);
     Py_DECREF(py_tracks);
     Py_DECREF(p);
@@ -322,6 +326,8 @@ playlist_tracks_moved_callback(sp_playlist * playlist, const int *tracks,
                                        py_tracks,
                                        Py_BuildValue("i", new_position),
                                        tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_XDECREF(res);
     Py_DECREF(py_tracks);
     Py_DECREF(p);
@@ -353,6 +359,8 @@ playlist_renamed_callback(sp_playlist * playlist, void *userdata)
     res = PyObject_CallFunctionObjArgs(tramp->callback,
                                        tramp->manager,
                                        p, tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_XDECREF(res);
     Py_DECREF(p);
     PyGILState_Release(gstate);
@@ -383,6 +391,8 @@ playlist_state_changed_callback(sp_playlist * playlist, void *userdata)
     res = PyObject_CallFunctionObjArgs(tramp->callback,
                                        tramp->manager,
                                        p, tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_XDECREF(res);
     Py_DECREF(p);
     PyGILState_Release(gstate);
@@ -415,6 +425,8 @@ playlist_update_in_progress_callback(sp_playlist * playlist,
     res = PyObject_CallFunctionObjArgs(tramp->callback,
                                        tramp->manager,
                                        p, pdone, tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_XDECREF(res);
     Py_DECREF(p);
     Py_DECREF(pdone);
@@ -448,6 +460,8 @@ playlist_metadata_updated_callback(sp_playlist * playlist, void *userdata)
     res = PyObject_CallFunctionObjArgs(tramp->callback,
                                        tramp->manager,
                                        p, tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_XDECREF(res);
     Py_DECREF(p);
     PyGILState_Release(gstate);
@@ -487,6 +501,8 @@ playlist_track_created_changed_callback(sp_playlist * playlist,
                                        p,
                                        ppos,
                                        puser, pwhen, tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_XDECREF(res);
     Py_DECREF(p);
     Py_DECREF(ppos);
@@ -525,6 +541,8 @@ playlist_track_message_changed_callback(sp_playlist * playlist,
     res = PyObject_CallFunctionObjArgs(tramp->callback,
                                        tramp->manager,
                                        p, ppos, pmess, tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_XDECREF(res);
     Py_DECREF(p);
     Py_DECREF(ppos);
@@ -561,6 +579,8 @@ playlist_track_seen_changed_callback(sp_playlist * playlist,
     res = PyObject_CallFunctionObjArgs(tramp->callback,
                                        tramp->manager,
                                        p, ppos, pseen, tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_XDECREF(res);
     Py_DECREF(p);
     Py_DECREF(ppos);
@@ -595,6 +615,8 @@ playlist_description_changed_callback(sp_playlist * playlist,
     res = PyObject_CallFunctionObjArgs(tramp->callback,
                                        tramp->manager,
                                        p, pdesc, tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_XDECREF(res);
     Py_DECREF(p);
     Py_DECREF(pdesc);
@@ -627,6 +649,8 @@ playlist_subscribers_changed_callback(sp_playlist * playlist, void *userdata)
     res = PyObject_CallFunctionObjArgs(tramp->callback,
                                        tramp->manager,
                                        p, tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_XDECREF(res);
     Py_DECREF(p);
     PyGILState_Release(gstate);
@@ -660,6 +684,8 @@ playlist_image_changed_callback(sp_playlist * playlist, const byte * image,
     res = PyObject_CallFunctionObjArgs(tramp->callback,
                                        tramp->manager,
                                        p, pimage, tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_XDECREF(res);
     Py_DECREF(p);
     Py_DECREF(pimage);

--- a/src/playlistcontainer.c
+++ b/src/playlistcontainer.c
@@ -125,6 +125,8 @@ playlistcontainer_loaded_callback(sp_playlistcontainer * playlistcontainer,
     res = PyObject_CallFunctionObjArgs(tramp->callback,
                                        tramp->manager,
                                        pc, tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_DECREF(pc);
     Py_XDECREF(res);
     PyGILState_Release(gstate);
@@ -159,6 +161,8 @@ playlistcontainer_playlist_added_callback(sp_playlistcontainer *
     res = PyObject_CallFunctionObjArgs(tramp->callback,
                                        tramp->manager,
                                        pc, p, pos, tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_DECREF(pc);
     Py_DECREF(p);
     Py_DECREF(pos);
@@ -200,6 +204,8 @@ playlistcontainer_playlist_moved_callback(sp_playlistcontainer *
                                        tramp->manager,
                                        pc,
                                        p, pos, new_pos, tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_DECREF(pc);
     Py_DECREF(p);
     Py_DECREF(pos);
@@ -239,6 +245,8 @@ playlistcontainer_playlist_removed_callback(sp_playlistcontainer *
     res = PyObject_CallFunctionObjArgs(tramp->callback,
                                        tramp->manager,
                                        pc, p, pos, tramp->userdata, NULL);
+    if (!res)
+        PyErr_WriteUnraisable(tramp->callback);
     Py_DECREF(pc);
     Py_DECREF(p);
     Py_DECREF(pos);


### PR DESCRIPTION
Hi,

I have found a way to inform a user about the exceptions happening in callbacks. I use the Python C API function `PyErr_WriteUnraisable(context)` (used in CPython for exceptions raised in `__del__` methods for example).

Sample output for session callbacks (better context):

```
Exception ZeroDivisionError: 'integer division or modulo by zero' in <bound method MockClient.logged_in of <tests.test_session.MockClient object at 0x15fb4d0>> ignored
```

playlist / container:

```
Exception ZeroDivisionError: 'integer division or modulo by zero' in <function container_loaded at 0x10c9050> ignored
```
