### PR TITLE
Upgrade to libspotify 10.1.11

### DIFF
--- a/docs/api/session.rst
+++ b/docs/api/session.rst
@@ -57,11 +57,6 @@ The :class:`Session` class
 
         Raises :exc:`SpotifyError` if not logged in.
 
-    .. method:: get_friends()
-
-        :rtype:     list of :class:`User`
-        :returns:   the list of friends for the current user.
-
     .. method:: image_create(id)
 
         :param string id:   the id of the image to be fetched.

--- a/docs/api/user.rst
+++ b/docs/api/user.rst
@@ -21,20 +21,3 @@ Users
         :rtype:     :class:`unicode`
         :returns:   the display name of the user, or the canonical name if
             not loaded.
-
-    .. method:: full_name
-
-        :rtype:     :class:`unicode`
-        :returns:   the full name of the user, or `None` if not loaded.
-
-    .. method:: picture
-
-        :rtype:     :class:`unicode`
-        :returns:   an url to this user’s picture.
-
-    .. method:: relation
-
-        :rtype:     :class:`int`
-        :returns:   the current user’s relation type with this user.
-
-        .. note::   Compare with one of :ref:`user-relation-types`.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,19 @@
 Changes
 =======
 
+v1.6 (in developpement)
+=======================
+
+Updated to work with libspotify 10.1.11.
+
+** API changes **
+
+- ``Session.is_available(track)`` is now
+  :meth:`spotify.Track.availability()`, and returns a detailed availability
+  status of the track.
+- Deleted methods: ``Session.get_friends``, ``User.full_name``,
+  ``User.picture``, ``User.relation``.
+
 v1.5 (2011-10-30)
 =================
 

--- a/spotify/constant.py
+++ b/spotify/constant.py
@@ -1,8 +1,0 @@
-# encoding: utf-8
-
-# User relation types
-from _spotify import                \
-RELATION_TYPE_UNKNOWN,              \
-RELATION_TYPE_NONE,                 \
-RELATION_TYPE_UNIDIRECTIONAL,       \
-RELATION_TYPE_BIDIRECTIONAL

--- a/src/artistbrowser.c
+++ b/src/artistbrowser.c
@@ -58,6 +58,7 @@ ArtistBrowser_new(PyTypeObject * type, PyObject *args, PyObject *kwds)
     self->_browser =
         sp_artistbrowse_create(((Session *) session)->_session,
                                ((Artist *) artist)->_artist,
+                               SP_ARTISTBROWSE_FULL,
                                (artistbrowse_complete_cb *)
                                ArtistBrowser_browse_complete,
                                (void *)&self->_callback);

--- a/src/session.c
+++ b/src/session.c
@@ -86,21 +86,6 @@ Session_display_name(Session * self)
 };
 
 static PyObject *
-Session_get_friends(Session * self)
-{
-    int i, friends_count = sp_session_num_friends(self->_session);
-    PyObject *user;
-    PyObject *friends_list = PyList_New(friends_count);
-
-    for(i = 0; i < friends_count; i++) {
-        user = User_FromSpotify(sp_session_friend(self->_session, i));
-        PyList_SetItem(friends_list, i, user);
-    }
-
-    return friends_list;
-};
-
-static PyObject *
 Session_user_is_loaded(Session * self)
 {
     sp_user *user;
@@ -186,18 +171,6 @@ Session_seek(Session * self, PyObject *args)
     sp_session_player_seek(self->_session, seek);
     Py_END_ALLOW_THREADS;
     Py_RETURN_NONE;
-}
-
-static PyObject *
-Track_is_available(Session * self, PyObject *args)
-{
-    Track *track;
-
-    if (!PyArg_ParseTuple(args, "O!", &TrackType, &track)) {
-        return NULL;
-    }
-    return Py_BuildValue("i",
-                         sp_track_is_available(self->_session, track->_track));
 }
 
 static PyObject *
@@ -381,8 +354,6 @@ static PyMethodDef Session_methods[] = {
      "Return the canonical username for the logged in user"},
     {"display_name", (PyCFunction)Session_display_name, METH_NOARGS,
      "Return the full name for the logged in user"},
-    {"get_friends", (PyCFunction)Session_get_friends, METH_NOARGS,
-     "Return a list of friends for the logged in user"},
     {"user_is_loaded", (PyCFunction)Session_user_is_loaded, METH_NOARGS,
      "Return whether the user is loaded or not"},
     {"logout", (PyCFunction)Session_logout, METH_NOARGS,
@@ -397,8 +368,6 @@ static PyMethodDef Session_methods[] = {
      "Play or pause the currently loaded track"},
     {"unload", (PyCFunction)Session_unload, METH_NOARGS,
      "Stop the currently playing track"},
-    {"is_available", (PyCFunction)Track_is_available, METH_VARARGS,
-     "Return true if the track is available for playback."},
     {"is_local", (PyCFunction)Track_is_local, METH_VARARGS,
      "Return true if the track is a local file."},
     {"playlist_container", (PyCFunction)Session_playlist_container,

--- a/src/track.c
+++ b/src/track.c
@@ -144,7 +144,18 @@ Track_starred(Track * self, PyObject *args, PyObject *kwds)
                                                            self->_track));
 }
 
+static PyObject *
+Track_availability(Track* self)
+{
+    return Py_BuildValue("i",
+                         sp_track_get_availability(g_session, self->_track));
+}
+
 static PyMethodDef Track_methods[] = {
+    {"availability",
+     (PyCFunction)Track_availability,
+     METH_NOARGS,
+     "Get availability status for this track."},
     {"is_loaded",
      (PyCFunction)Track_is_loaded,
      METH_NOARGS,

--- a/src/user.c
+++ b/src/user.c
@@ -60,42 +60,12 @@ User_display_name(User * self)
 }
 
 static PyObject *
-User_full_name(User * self)
-{
-    const char *s = sp_user_full_name(self->_user);
-
-    if (!s)
-        Py_RETURN_NONE;
-    return PyUnicode_FromString(s);
-}
-
-static PyObject *
 User_str(PyObject *self)
 {
     User *a = (User *) self;
     const char *s = sp_user_canonical_name(a->_user);
 
     return PyUnicode_FromString(s);
-}
-
-static PyObject *
-User_picture(User *self)
-{
-    const char *picture;
-
-    picture = sp_user_picture(self->_user);
-    if (!picture)
-        Py_RETURN_NONE;
-    return PyUnicode_FromString(picture);
-}
-
-static PyObject *
-User_relation(User *self)
-{
-    sp_relation_type relation;
-
-    relation = sp_user_relation_type(g_session, self->_user);
-    return Py_BuildValue("i", relation);
 }
 
 static PyMethodDef User_methods[] = {
@@ -111,18 +81,6 @@ static PyMethodDef User_methods[] = {
      (PyCFunction) User_display_name,
      METH_NOARGS,
      "Returns the display name of the user"},
-    {"full_name",
-     (PyCFunction) User_full_name,
-     METH_NOARGS,
-     "Returns the full name of the user"},
-    {"picture",
-     (PyCFunction) User_picture,
-     METH_NOARGS,
-     "Returns an url to this user's picture."},
-    {"relation",
-     (PyCFunction) User_relation,
-     METH_NOARGS,
-     "Returns the current user's relation type with this user."},
     {NULL}
 };
 

--- a/tests/test_globals.py
+++ b/tests/test_globals.py
@@ -4,4 +4,4 @@ import spotify
 class TestGlobals(unittest.TestCase):
 
     def test_api_version(self):
-        self.assertEqual(spotify.api_version, 9)
+        self.assertEqual(spotify.api_version, 10)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -60,19 +60,6 @@ class TestSession(unittest.TestCase):
         c.connect()
         self.assertEqual(c.username, c.found_username)
 
-    def test_friends(self):
-        class MockClient(BaseMockClient):
-            def logged_in(self, session, error):
-                username = session.username()
-                self.friends = session.get_friends()
-                session.logout()
-                self.disconnect()
-
-        c = MockClient()
-        c.connect()
-        self.assertEqual([f.canonical_name() for f in c.friends],
-                         ['foo', 'bar', 'baz'])
-
     def NOtest_load(self):
         class MockClient(BaseMockClient):
             def logged_in(self, session, error):

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -43,3 +43,5 @@ class TestTrack(unittest.TestCase):
         self.track.starred(session, set=False)
         self.assertEqual(self.track.starred(session), False)
 
+    def test_availability(self):
+        self.assertEqual(self.track.availability(), 1)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -8,46 +8,24 @@ from spotify.constant import RELATION_TYPE_BIDIRECTIONAL
 class TestUser(unittest.TestCase):
 
     def test_str(self):
-        user = mock_user(u'foo',u'bar',u'baz',u'url',0,1);
+        user = mock_user(u'foo',u'bar',1);
         self.assertEqual(str(user), u'foo')
 
     def test_is_loaded(self):
-        user = mock_user('','','','',0,1);
+        user = mock_user('','',1);
         self.assertEqual(user.is_loaded(), True)
-        user = mock_user('','','','',0,0);
+        user = mock_user('','',0);
         self.assertEqual(user.is_loaded(), False)
 
     def test_canonical_name(self):
-        user = mock_user(u'foo',u'bar',u'baz',u'url',0,1);
+        user = mock_user(u'foo',u'bar',1);
         self.assertEqual(user.canonical_name(), u'foo')
 
     def test_display_name(self):
-        user = mock_user(u'foo',u'bar',u'baz',u'url',0,1);
+        user = mock_user(u'foo',u'bar',1);
         self.assertEqual(user.display_name(), u'bar')
 
-    def test_full_name(self):
-        user = mock_user(u'foo',u'bar',u'baz',u'url',0,1);
-        self.assertEqual(user.full_name(), u'baz')
-
-    def test_full_name_not_loaded(self):
-        user = mock_user(u'foo',u'bar',u'baz',u'url',0,0);
-        self.assertEqual(user.full_name(), None)
-
-    def test_picture(self):
-        user = mock_user(u'foo',u'bar',u'baz',u'url',0,1);
-        self.assertEqual(user.picture(), u'url')
-
-    def test_picture_not_loaded(self):
-        user = mock_user(u'foo',u'bar',u'baz',u'url',0,0);
-        self.assertEqual(user.picture(), None)
-
-    def test_relation(self):
-        user = mock_user(u'foo',u'bar',u'baz',u'url',3,1);
-        self.assertEqual(user.relation(), RELATION_TYPE_BIDIRECTIONAL)
-
     def test_unicode(self):
-        user = mock_user(u'føø',u'bãr',u'båz',u'ürl',0,1);
+        user = mock_user(u'føø',u'bãr',1);
         self.assertEqual(user.canonical_name(), u'føø')
         self.assertEqual(user.display_name(), u'bãr')
-        self.assertEqual(user.full_name(), u'båz')
-        self.assertEqual(user.picture(), u'ürl')


### PR DESCRIPTION
Changelog:
# v1.6 (in developpement)

Updated to work with libspotify 10.1.11.

*\* API changes **
- `Session.is_available(track)` is now
  :meth:`spotify.Track.availability()`, and returns a detailed availability
  status of the track.
- Deleted methods: `Session.get_friends`, `User.full_name`,
  `User.picture`, `User.relation`.
