### PR TITLE
sp_playlist_track_create_time function

### DIFF
--- a/src/playlist.c
+++ b/src/playlist.c
@@ -727,6 +727,17 @@ Playlist_remove_callback(Playlist * self, PyObject *args)
 }
 
 static PyObject *
+Playlist_track_create_time(Playlist * self, PyObject *args)
+{
+	int num_track;
+	if (!PyArg_ParseTuple(args, "i", &num_track))
+        return NULL;
+
+	int when = sp_playlist_track_create_time(self->_playlist, num_track);
+	return Py_BuildValue("i", when);
+}
+
+static PyObject *
 Playlist_name(Playlist * self)
 {
     const char *name = sp_playlist_name(self->_playlist);
@@ -922,6 +933,10 @@ static PyMethodDef Playlist_methods[] = {
      (PyCFunction)Playlist_remove_callback,
      METH_VARARGS,
      ""},
+ 	{"track_create_time",
+     (PyCFunction)Playlist_track_create_time,
+     METH_VARARGS,
+     "Return when the given index was added to the playlist"},
     {"name",
      (PyCFunction)Playlist_name,
      METH_NOARGS,


### PR DESCRIPTION
Simple wrapping of original sp_playlist_track_create_time function.

Return when the given index was added to the playlist. (unix timestamp)
