### PR TITLE
Fix potential null-pointer dereference catched by clang's scan-build tool

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -583,7 +583,7 @@ music_delivery(sp_session * session, const sp_audioformat * format,
     int consumed = num_frames;  // assume all consumed
     if (!res)
         PyErr_WriteUnraisable(method);
-    if (PyInt_Check(res))
+    else if (PyInt_Check(res))
         consumed = (int)PyInt_AsLong(res);
     else if (PyLong_Check(res))
         consumed = (int)PyLong_AsLong(res);


### PR DESCRIPTION
`PyInt_Check(res)` does a dereference of `res`, which may be null.

I found the potential error by installing clang and building pyspotify with clang's build-scan tool:

```
rm -rf build/; scan-build python setup.py build; PYTHONPATH=$(echo build/lib.linux-*/) nosetests
```

The warning:

```
src/session.c:586:9: warning: Access to field 'ob_type' results in a dereference of a null pointer (loaded from variable 'res')
    if (PyInt_Check(res))
        ^~~~~~~~~~~~~~~~
/usr/include/python2.7/intobject.h:31:4: note: expanded from:
                 PyType_FastSubclass((op)->ob_type, Py_TPFLAGS_INT_SUBCLASS)
                 ^
/usr/include/python2.7/object.h:648:35: note: expanded from:
#define PyType_FastSubclass(t,f)  PyType_HasFeature(t,f)
                                  ^
/usr/include/python2.7/object.h:647:35: note: expanded from:
#define PyType_HasFeature(t,f)  (((t)->tp_flags & (f)) != 0)
                                  ^~
1 warning generated.
```

Please validate my that my fix makes sense. I only checked that the code still passes the unit tests.
