### PR TITLE
Print out a pretty duration in the jukebox.

### DIFF
--- a/examples/jukebox.py
+++ b/examples/jukebox.py
@@ -62,9 +62,19 @@ class JukeboxUI(cmd.Cmd, threading.Thread):
                 playlist = self.jukebox.starred
             for i, t in enumerate(playlist):
                 if t.is_loaded():
-                    print "%3d %s - %s" % (i, t.artists()[0].name(), t.name())
+                    print "%3d %s - %s [%s]" % (i,
+                                                t.artists()[0].name(),
+                                                t.name(),
+                                                self.pretty_duration(t.duration()))
                 else:
                     print "%3d %s" % (i, "loading...")
+
+    def pretty_duration(self, milliseconds):
+        seconds = milliseconds // 1000
+        minutes = int(seconds) / 60
+        seconds = int(seconds) % 60
+        duration = '%02d:%02d' % (minutes, seconds)
+        return duration
 
     def do_play(self, line):
         if not line:


### PR DESCRIPTION
When using list on a playlist, it's nice to see how long the tracks are, (also gives an easy example of calculating duration)
