### PR TITLE
Use proxy capability of libspotify

### DIFF
--- a/spotify/manager/session.py
+++ b/spotify/manager/session.py
@@ -32,11 +32,15 @@ class SpotifySessionManager(object):
     user_agent = 'pyspotify-example'
 
     def __init__(self, username=None, password=None, remember_me=False,
-                 login_blob=''):
+                 login_blob='', proxy=None, proxy_username=None,
+                 proxy_password=None):
         self._cmdqueue = Queue.Queue()
         self.username = username
         self.password = password
         self.remember_me = remember_me
+        self.proxy = proxy
+        self.proxy_username = proxy_username
+        self.proxy_password = proxy_password
         self.login_blob = login_blob
         if self.application_key is None:
             self.application_key = open(self.appkey_file).read()

--- a/src/session.c
+++ b/src/session.c
@@ -822,6 +822,7 @@ session_connect(PyObject *self, PyObject *args)
     sp_error error;
     char *username, *password;
     char *cache_location, *settings_location, *user_agent;
+    char *proxy, *proxy_username, *proxy_password;
     bool relogin = 0, remember_me;
     char *blob = NULL;
 
@@ -883,6 +884,39 @@ session_connect(PyObject *self, PyObject *args)
         fprintf(stderr, "[DEBUG]-session- User agent set to '%s'\n",
                             user_agent);
 #endif
+
+    proxy = PySpotify_GetConfigString(client, "proxy", 1);
+    if (!proxy)
+        return NULL;
+    if ((long) proxy != (-1)) {
+    config.proxy = proxy;
+#ifdef DEBUG
+    fprintf(stderr, "[DEBUG]-session- Proxy set to '%s'\n", proxy);
+#endif
+    }
+
+    proxy_username = PySpotify_GetConfigString(client, "proxy_username", 1);
+    if (!proxy_username)
+       return NULL;
+    if ((long) proxy_username != (-1)) {
+        config.proxy_username = proxy_username;
+#ifdef DEBUG
+        fprintf(stderr, "[DEBUG]-session- Proxy username set to '%s'\n",
+            proxy_username);
+#endif
+    }
+
+    proxy_password = PySpotify_GetConfigString(client, "proxy_password", 1);
+    if (!proxy_password)
+       return NULL;
+    if ((long) proxy_password != (-1)) {
+        config.proxy_password = proxy_password;
+#ifdef DEBUG
+        fprintf(stderr, "[DEBUG]-session- Proxy password set to '%s'\n",
+            proxy_password);
+#endif
+    }
+
     username = PySpotify_GetConfigString(client, "username", 1);
     if (!username)
         return NULL;


### PR DESCRIPTION
I open a new pull request since the first is closed. Spacing is now fixed.
:
Hello,

I've just patched pyspotify to use proxy, proxy_username and proxy_password settings.

1) Add proxy, proxy_username, proxy_password values when instancing SpotifySessionManager.
2) Modify session.c to pass the option to libspotify.

I don't know if it is the right way to do this, anyway it works well : Successfull connection with modipy behind a proxy. I will submit my commit to modipy if this one is pulled.

David
