### PR TITLE
fixed AlsaSink audio underuns on RasperryPI

### DIFF
--- a/spotify/audiosink/alsa.py
+++ b/spotify/audiosink/alsa.py
@@ -10,7 +10,7 @@ class AlsaSink(BaseAudioSink):
         super(AlsaSink, self).__init__(**kwargs)
         self._mode = kwargs.get('mode', alsaaudio.PCM_NONBLOCK)
         self._device = None
-        self._periodesize = 8192
+        self._periodsize = kwargs.get('periodsize', 8192)
         if sys.byteorder == 'little':
             self._format = alsaaudio.PCM_FORMAT_S16_LE
         elif sys.byteorder == 'big':
@@ -20,7 +20,7 @@ class AlsaSink(BaseAudioSink):
             sample_type, sample_rate, channels):
         if self._device is None:
             self._device = alsaaudio.PCM(mode=self._mode)
-            self._device.setperiodsize(self._periodesize)
+            self._device.setperiodsize(self._periodsize)
             self._device.setformat(self._format)
         if num_frames == 0:
             return 0


### PR DESCRIPTION
- changed alsa device mode to PCM_NONBLOCK
  - libspotify documentation says that the music_delivery callback
    should not block
- changed periodesize to an constant value
  - setting periodesize to num_frames caused problems if num_frames got to low.
    for example the last music_delivery at the end of track
    raised an alsa error
- return in AlsaSink.music_delivery if num_frames is 0

should also fix issue #83
