### PR TITLE
Adjusted jukebox example to handle PlaylistFolder objects

### DIFF
--- a/examples/jukebox.py
+++ b/examples/jukebox.py
@@ -7,7 +7,7 @@ import os
 import threading
 import time
 
-from spotify import ArtistBrowser, Link, ToplistBrowser, SpotifyError
+from spotify import ArtistBrowser, Link, Playlist, ToplistBrowser, SpotifyError
 from spotify.audiosink import import_audio_sink
 from spotify.manager import (
     SpotifySessionManager, SpotifyPlaylistManager, SpotifyContainerManager)
@@ -51,7 +51,8 @@ class JukeboxUI(cmd.Cmd, threading.Thread):
             i = -1
             for i, p in enumerate(self.jukebox.ctr):
                 if p.is_loaded():
-                    if Link.from_playlist(p).type() == Link.LINK_STARRED:
+                    if (isinstance(p, Playlist) and
+                        Link.from_playlist(p).type() == Link.LINK_STARRED):
                         name = "Starred by %s" % p.owner()
                     else:
                         name = p.name()


### PR DESCRIPTION
I got a TypeError with the 'ls'/'list' command. This is a quick fix to get the example running.

``` python
jukebox> ls
Stopping
Goodbye!
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 552, in __bootstrap_inner
    self.run()
  File "jukebox.py", line 35, in run
    self.cmdloop()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/cmd.py", line 142, in cmdloop
    stop = self.onecmd(line)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/cmd.py", line 219, in onecmd
    return func(arg)
  File "jukebox.py", line 54, in do_list
    if Link.from_playlist(p).type() == Link.LINK_STARRED:
TypeError: must be spotify.Playlist, not spotify.PlaylistFolder

Logged out!
```
