### PR TITLE
Fixed search results totals

### DIFF
--- a/examples/shell.py
+++ b/examples/shell.py
@@ -203,8 +203,8 @@ class SpotifyLoop(threading.Thread):
             return
         self.logger.info(
             '%d tracks, %d albums, %d artists, and %d playlists found.',
-            result.total_tracks, result.total_albums,
-            result.total_artists, result.total_playlists)
+            result.track_total, result.album_total,
+            result.artist_total, result.playlist_total)
         self.logger.info('Top tracks:')
         for track in result.tracks:
             self.logger.info(


### PR DESCRIPTION
Fixes:

```
INFO:spotify.session:Logged in
spotify> search queens
spotify> Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 552, in __bootstrap_inner
    self.run()
  File "shell.py", line 137, in run
    stop = action(*args)
  File "shell.py", line 206, in do_search
    result.total_tracks, result.total_albums,
AttributeError: 'Search' object has no attribute 'total_tracks'
```
