### PR TITLE
Update to the Mac OS X libspotify install

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -61,6 +61,8 @@ Mac OS X
 If you're using `Homebrew <http://brew.sh/>`_, it has a formula for
 libspotify::
 
+    brew tap homebrew/binary
+
     brew install libspotify
 
 TODO: Check if pyspotify works with the Mac OS X download option from the


### PR DESCRIPTION
Before trying to install libspotify with brew, the user should tap into homebrew binary formulae
