### PR TITLE
Linter updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ workflows:
       - docs
       - flake8
       - check-manifest
-      - black
 
 jobs:
   py39: &test-template
@@ -106,5 +105,3 @@ jobs:
   flake8: *test-template
 
   check-manifest: *test-template
-
-  black: *test-template

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,13 +21,13 @@ def get_version():
     # Get current library version without requiring the library to be
     # installed, like ``pkg_resources.get_distribution(...).version`` requires.
     cp = configparser.ConfigParser()
-    cp.read(os.path.join(os.path.dirname(__file__), '..', 'setup.cfg'))
-    return cp['metadata']['version']
+    cp.read(os.path.join(os.path.dirname(__file__), "..", "setup.cfg"))
+    return cp["metadata"]["version"]
 
 
 # -- Workarounds to have autodoc generate API docs ----------------------------
 
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(".."))
 
 
 # Mock cffi module
@@ -35,21 +35,21 @@ module = mock.Mock()
 module.ffi = mock.Mock()
 module.ffi.CData = bytes
 module.lib = mock.Mock()
-module.lib.sp_error_message.return_value = b''
-module.lib.sp_error_message.__name__ = str('sp_error_message')
-sys.modules['spotify._spotify'] = module
+module.lib.sp_error_message.return_value = b""
+module.lib.sp_error_message.__name__ = str("sp_error_message")
+sys.modules["spotify._spotify"] = module
 
 
 # Mock pkg_resources module
 module = mock.Mock()
 module.get_distribution.return_value.version = get_version()
-sys.modules['pkg_resources'] = module
+sys.modules["pkg_resources"] = module
 
 
 # Add all libspotify constants to the lib mock
-with open('sp-constants.csv') as fh:
+with open("sp-constants.csv") as fh:
     for line in fh.readlines():
-        key, value = line.split(',', 1)
+        key, value = line.split(",", 1)
         setattr(module.lib, key, value)
 
 
@@ -57,70 +57,70 @@ with open('sp-constants.csv') as fh:
 import spotify  # noqa
 
 for mod_name, mod in vars(spotify).items():
-    if not isinstance(mod, types.ModuleType) or mod_name in ('threading',):
+    if not isinstance(mod, types.ModuleType) or mod_name in ("threading",):
         continue
     for cls in vars(mod).values():
         if not isinstance(cls, type):
             continue
         for method_name, method in vars(cls).items():
-            if hasattr(method, '__wrapped__'):
+            if hasattr(method, "__wrapped__"):
                 setattr(cls, method_name, method.__wrapped__)
 
 
 # -- General configuration ----------------------------------------------------
 
-needs_sphinx = '1.0'
+needs_sphinx = "1.0"
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.extlinks',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.viewcode',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.extlinks",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
 ]
 
-templates_path = ['_templates']
-source_suffix = '.rst'
-master_doc = 'index'
+templates_path = ["_templates"]
+source_suffix = ".rst"
+master_doc = "index"
 
-project = 'pyspotify'
-copyright = '2013-2019, Stein Magnus Jodal and contributors'
+project = "pyspotify"
+copyright = "2013-2019, Stein Magnus Jodal and contributors"
 
 release = get_version()
-version = '.'.join(release.split('.')[:2])
+version = ".".join(release.split(".")[:2])
 
-exclude_patterns = ['_build']
+exclude_patterns = ["_build"]
 
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
-modindex_common_prefix = ['spotify.']
+modindex_common_prefix = ["spotify."]
 
-autodoc_default_flags = ['members', 'undoc-members', 'inherited-members']
-autodoc_member_order = 'bysource'
+autodoc_default_flags = ["members", "undoc-members", "inherited-members"]
+autodoc_member_order = "bysource"
 
 intersphinx_mapping = {
-    'python': ('http://docs.python.org/3/', None),
-    'pyalsaaudio': ('https://larsimmisch.github.io/pyalsaaudio/', None),
+    "python": ("http://docs.python.org/3/", None),
+    "pyalsaaudio": ("https://larsimmisch.github.io/pyalsaaudio/", None),
 }
 
 
 # -- Options for HTML output --------------------------------------------------
 
 # html_theme = 'default'
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 html_use_modindex = True
 html_use_index = True
 html_split_index = False
 html_show_sourcelink = True
 
-htmlhelp_basename = 'pyspotify'
+htmlhelp_basename = "pyspotify"
 
 # -- Options for extlink extension --------------------------------------------
 
 extlinks = {
-    'issue': ('https://github.com/jodal/pyspotify/issues/%s', '#'),
-    'ms-issue': (
-        'https://github.com/mopidy/mopidy-spotify/issues/%s',
-        'mopidy-spotify#',
+    "issue": ("https://github.com/jodal/pyspotify/issues/%s", "#"),
+    "ms-issue": (
+        "https://github.com/mopidy/mopidy-spotify/issues/%s",
+        "mopidy-spotify#",
     ),
 }

--- a/examples/cover.py
+++ b/examples/cover.py
@@ -9,8 +9,8 @@ session.relogin()
 while session.connection.state != spotify.ConnectionState.LOGGED_IN:
     session.process_events()
 
-album = session.get_album('spotify:album:4m2880jivSbbyEGAKfITCa').load()
+album = session.get_album("spotify:album:4m2880jivSbbyEGAKfITCa").load()
 cover = album.cover(spotify.ImageSize.LARGE).load()
 
-open('/tmp/cover.jpg', 'wb').write(cover.data)
-open('/tmp/cover.html', 'w').write('<img src="%s">' % cover.data_uri)
+open("/tmp/cover.jpg", "wb").write(cover.data)
+open("/tmp/cover.html", "w").write('<img src="%s">' % cover.data_uri)

--- a/examples/play_track.py
+++ b/examples/play_track.py
@@ -26,7 +26,7 @@ import spotify
 if sys.argv[1:]:
     track_uri = sys.argv[1]
 else:
-    track_uri = 'spotify:track:6xZtSE6xaBxmRozKA0F6TA'
+    track_uri = "spotify:track:6xZtSE6xaBxmRozKA0F6TA"
 
 # Assuming a spotify_appkey.key in the current dir
 session = spotify.Session()

--- a/examples/play_track.py
+++ b/examples/play_track.py
@@ -53,9 +53,7 @@ def on_end_of_track(self):
 
 
 # Register event listeners
-session.on(
-    spotify.SessionEvent.CONNECTION_STATE_UPDATED, on_connection_state_updated
-)
+session.on(spotify.SessionEvent.CONNECTION_STATE_UPDATED, on_connection_state_updated)
 session.on(spotify.SessionEvent.END_OF_TRACK, on_end_of_track)
 
 # Assuming a previous login with remember_me=True and a proper logout

--- a/examples/shell.py
+++ b/examples/shell.py
@@ -22,10 +22,10 @@ import spotify
 
 class Commander(cmd.Cmd):
 
-    doc_header = 'Commands'
-    prompt = 'spotify> '
+    doc_header = "Commands"
+    prompt = "spotify> "
 
-    logger = logging.getLogger('shell.commander')
+    logger = logging.getLogger("shell.commander")
 
     def __init__(self):
         cmd.Cmd.__init__(self)
@@ -44,7 +44,7 @@ class Commander(cmd.Cmd):
         try:
             self.audio_driver = spotify.AlsaSink(self.session)
         except ImportError:
-            self.logger.warning('No audio sink found; audio playback unavailable.')
+            self.logger.warning("No audio sink found; audio playback unavailable.")
 
         self.event_loop = spotify.EventLoop(self.session)
         self.event_loop.start()
@@ -62,7 +62,7 @@ class Commander(cmd.Cmd):
 
     def precmd(self, line):
         if line:
-            self.logger.debug('New command: %s', line)
+            self.logger.debug("New command: %s", line)
         return line
 
     def emptyline(self):
@@ -70,35 +70,35 @@ class Commander(cmd.Cmd):
 
     def do_debug(self, line):
         "Show more logging output"
-        print('Logging at DEBUG level')
+        print("Logging at DEBUG level")
         logger = logging.getLogger()
         logger.setLevel(logging.DEBUG)
 
     def do_info(self, line):
         "Show normal logging output"
-        print('Logging at INFO level')
+        print("Logging at INFO level")
         logger = logging.getLogger()
         logger.setLevel(logging.INFO)
 
     def do_warning(self, line):
         "Show less logging output"
-        print('Logging at WARNING level')
+        print("Logging at WARNING level")
         logger = logging.getLogger()
         logger.setLevel(logging.WARNING)
 
     def do_EOF(self, line):
         "Exit"
         if self.logged_in.is_set():
-            print('Logging out...')
+            print("Logging out...")
             self.session.logout()
             self.logged_out.wait()
         self.event_loop.stop()
-        print('')
+        print("")
         return True
 
     def do_login(self, line):
         "login <username> <password>"
-        tokens = line.split(' ', 1)
+        tokens = line.split(" ", 1)
         if len(tokens) != 2:
             self.logger.warning("Wrong number of arguments")
             return
@@ -127,21 +127,21 @@ class Commander(cmd.Cmd):
         "whoami"
         if self.logged_in.is_set():
             self.logger.info(
-                'I am %s aka %s. You can find me at %s',
+                "I am %s aka %s. You can find me at %s",
                 self.session.user.canonical_name,
                 self.session.user.display_name,
                 self.session.user.link,
             )
         else:
             self.logger.info(
-                'I am not logged in, but I may be %s',
+                "I am not logged in, but I may be %s",
                 self.session.remembered_user,
             )
 
     def do_play_uri(self, line):
         "play <spotify track uri>"
         if not self.logged_in.is_set():
-            self.logger.warning('You must be logged in to play')
+            self.logger.warning("You must be logged in to play")
             return
         try:
             track = self.session.get_track(line)
@@ -149,38 +149,38 @@ class Commander(cmd.Cmd):
         except (ValueError, spotify.Error) as e:
             self.logger.warning(e)
             return
-        self.logger.info('Loading track into player')
+        self.logger.info("Loading track into player")
         self.session.player.load(track)
-        self.logger.info('Playing track')
+        self.logger.info("Playing track")
         self.session.player.play()
 
     def do_pause(self, line):
-        self.logger.info('Pausing track')
+        self.logger.info("Pausing track")
         self.session.player.play(False)
 
     def do_resume(self, line):
-        self.logger.info('Resuming track')
+        self.logger.info("Resuming track")
         self.session.player.play()
 
     def do_stop(self, line):
-        self.logger.info('Stopping track')
+        self.logger.info("Stopping track")
         self.session.player.play(False)
         self.session.player.unload()
 
     def do_seek(self, seconds):
         "seek <seconds>"
         if not self.logged_in.is_set():
-            self.logger.warning('You must be logged in to seek')
+            self.logger.warning("You must be logged in to seek")
             return
         if self.session.player.state is spotify.PlayerState.UNLOADED:
-            self.logger.warning('A track must be loaded before seeking')
+            self.logger.warning("A track must be loaded before seeking")
             return
         self.session.player.seek(int(seconds) * 1000)
 
     def do_search(self, query):
         "search <query>"
         if not self.logged_in.is_set():
-            self.logger.warning('You must be logged in to search')
+            self.logger.warning("You must be logged in to search")
             return
         try:
             result = self.session.search(query)
@@ -189,19 +189,19 @@ class Commander(cmd.Cmd):
             self.logger.warning(e)
             return
         self.logger.info(
-            '%d tracks, %d albums, %d artists, and %d playlists found.',
+            "%d tracks, %d albums, %d artists, and %d playlists found.",
             result.track_total,
             result.album_total,
             result.artist_total,
             result.playlist_total,
         )
-        self.logger.info('Top tracks:')
+        self.logger.info("Top tracks:")
         for track in result.tracks:
             self.logger.info(
-                '[%s] %s - %s', track.link, track.artists[0].name, track.name
+                "[%s] %s - %s", track.link, track.artists[0].name, track.name
             )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     Commander().cmdloop()

--- a/examples/shell.py
+++ b/examples/shell.py
@@ -44,9 +44,7 @@ class Commander(cmd.Cmd):
         try:
             self.audio_driver = spotify.AlsaSink(self.session)
         except ImportError:
-            self.logger.warning(
-                'No audio sink found; audio playback unavailable.'
-            )
+            self.logger.warning('No audio sink found; audio playback unavailable.')
 
         self.event_loop = spotify.EventLoop(self.session)
         self.event_loop.start()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ requires = ["setuptools >= 30.3.0", "wheel"]
 
 [tool.black]
 target-version = ["py27"]
-skip-string-normalization = true
 
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ requires = ["setuptools >= 30.3.0", "wheel"]
 
 [tool.black]
 target-version = ["py27"]
-line-length = 80
 skip-string-normalization = true
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,7 @@ requires = ["setuptools >= 30.3.0", "wheel"]
 target-version = ["py27"]
 line-length = 80
 skip-string-normalization = true
+
+
+[tool.isort]
+profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,8 +45,8 @@ lint =
     check-manifest
     flake8
     flake8-bugbear
-    flake8-import-order
-    isort[pyproject]
+    flake8-isort
+    isort
 release =
     delocate
     twine

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ lint =
     black
     check-manifest
     flake8
+    flake8-black
     flake8-bugbear
     flake8-isort
     isort
@@ -80,6 +81,8 @@ select =
     B
     # B950: line too long (soft speed limit)
     B950
+    # flake8-black rules
+    BLK
     # pep8-naming rules
     N
 ignore =

--- a/setup.py
+++ b/setup.py
@@ -2,5 +2,5 @@ from setuptools import setup
 
 setup(
     # XXX Setting cffi_modules in setup.cfg does not have any effect.
-    cffi_modules=['spotify/_spotify_build.py:ffi']
+    cffi_modules=["spotify/_spotify_build.py:ffi"]
 )

--- a/spotify/__init__.py
+++ b/spotify/__init__.py
@@ -4,7 +4,6 @@ import threading
 
 import pkg_resources
 
-
 __version__ = pkg_resources.get_distribution('pyspotify').version
 
 

--- a/spotify/__init__.py
+++ b/spotify/__init__.py
@@ -4,7 +4,7 @@ import threading
 
 import pkg_resources
 
-__version__ = pkg_resources.get_distribution('pyspotify').version
+__version__ = pkg_resources.get_distribution("pyspotify").version
 
 
 # Global reentrant lock to be held whenever libspotify functions are called or
@@ -28,7 +28,7 @@ def _setup_logging():
     """
     import logging
 
-    logger = logging.getLogger('spotify')
+    logger = logging.getLogger("spotify")
     handler = logging.NullHandler()
     logger.addHandler(handler)
 
@@ -65,7 +65,7 @@ def serialized(f):
         with _lock:
             return f(*args, **kwargs)
 
-    if not hasattr(wrapper, '__wrapped__'):
+    if not hasattr(wrapper, "__wrapped__"):
         # Workaround for Python < 3.2
         wrapper.__wrapped__ = f
     return wrapper
@@ -80,7 +80,7 @@ class _SerializedLib(object):
     def __init__(self, lib):
         for name in dir(lib):
             attr = getattr(lib, name)
-            if name.startswith('sp_') and callable(attr):
+            if name.startswith("sp_") and callable(attr):
                 attr = serialized(attr)
             setattr(self, name, attr)
 

--- a/spotify/_spotify_build.py
+++ b/spotify/_spotify_build.py
@@ -3,7 +3,6 @@ from distutils.version import StrictVersion
 
 import cffi
 
-
 if StrictVersion(cffi.__version__) < StrictVersion('1.0.0'):
     raise RuntimeError(
         'pyspotify requires cffi >= 1.0, but found %s' % cffi.__version__

--- a/spotify/_spotify_build.py
+++ b/spotify/_spotify_build.py
@@ -17,9 +17,7 @@ with open(header_file) as fh:
 
 ffi = cffi.FFI()
 ffi.cdef(header)
-ffi.set_source(
-    'spotify._spotify', '#include "libspotify/api.h"', libraries=['spotify']
-)
+ffi.set_source('spotify._spotify', '#include "libspotify/api.h"', libraries=['spotify'])
 
 
 if __name__ == '__main__':

--- a/spotify/_spotify_build.py
+++ b/spotify/_spotify_build.py
@@ -3,22 +3,22 @@ from distutils.version import StrictVersion
 
 import cffi
 
-if StrictVersion(cffi.__version__) < StrictVersion('1.0.0'):
+if StrictVersion(cffi.__version__) < StrictVersion("1.0.0"):
     raise RuntimeError(
-        'pyspotify requires cffi >= 1.0, but found %s' % cffi.__version__
+        "pyspotify requires cffi >= 1.0, but found %s" % cffi.__version__
     )
 
 
-header_file = os.path.join(os.path.dirname(__file__), 'api.processed.h')
+header_file = os.path.join(os.path.dirname(__file__), "api.processed.h")
 
 with open(header_file) as fh:
     header = fh.read()
-    header += '#define SPOTIFY_API_VERSION ...\n'
+    header += "#define SPOTIFY_API_VERSION ...\n"
 
 ffi = cffi.FFI()
 ffi.cdef(header)
-ffi.set_source('spotify._spotify', '#include "libspotify/api.h"', libraries=['spotify'])
+ffi.set_source("spotify._spotify", '#include "libspotify/api.h"', libraries=["spotify"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     ffi.compile()

--- a/spotify/album.py
+++ b/spotify/album.py
@@ -33,9 +33,7 @@ class Album(object):
         if uri is not None:
             album = spotify.Link(self._session, uri=uri).as_album()
             if album is None:
-                raise ValueError(
-                    'Failed to get album from Spotify URI: %r' % uri
-                )
+                raise ValueError('Failed to get album from Spotify URI: %r' % uri)
             sp_album = album._sp_album
             add_ref = True
 
@@ -131,9 +129,7 @@ class Album(object):
         """
         if image_size is None:
             image_size = spotify.ImageSize.NORMAL
-        sp_link = lib.sp_link_create_from_album_cover(
-            self._sp_album, int(image_size)
-        )
+        sp_link = lib.sp_link_create_from_album_cover(self._sp_album, int(image_size))
         return spotify.Link(self._session, sp_link=sp_link, add_ref=False)
 
     @property
@@ -181,9 +177,7 @@ class Album(object):
 
         Can be created without the album being loaded.
         """
-        return spotify.AlbumBrowser(
-            self._session, album=self, callback=callback
-        )
+        return spotify.AlbumBrowser(self._session, album=self, callback=callback)
 
 
 class AlbumBrowser(object):
@@ -230,9 +224,7 @@ class AlbumBrowser(object):
 
         if add_ref:
             lib.sp_albumbrowse_add_ref(sp_albumbrowse)
-        self._sp_albumbrowse = ffi.gc(
-            sp_albumbrowse, lib.sp_albumbrowse_release
-        )
+        self._sp_albumbrowse = ffi.gc(sp_albumbrowse, lib.sp_albumbrowse_release)
 
     def __repr__(self):
         if self.is_loaded:
@@ -327,9 +319,7 @@ class AlbumBrowser(object):
 
         @serialized
         def get_copyright(sp_albumbrowse, key):
-            return utils.to_unicode(
-                lib.sp_albumbrowse_copyright(sp_albumbrowse, key)
-            )
+            return utils.to_unicode(lib.sp_albumbrowse_copyright(sp_albumbrowse, key))
 
         return utils.Sequence(
             sp_obj=self._sp_albumbrowse,

--- a/spotify/album.py
+++ b/spotify/album.py
@@ -6,7 +6,6 @@ import threading
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-
 __all__ = ['Album', 'AlbumBrowser', 'AlbumType']
 
 logger = logging.getLogger(__name__)

--- a/spotify/album.py
+++ b/spotify/album.py
@@ -6,7 +6,7 @@ import threading
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-__all__ = ['Album', 'AlbumBrowser', 'AlbumType']
+__all__ = ["Album", "AlbumBrowser", "AlbumType"]
 
 logger = logging.getLogger(__name__)
 
@@ -26,14 +26,14 @@ class Album(object):
     """
 
     def __init__(self, session, uri=None, sp_album=None, add_ref=True):
-        assert uri or sp_album, 'uri or sp_album is required'
+        assert uri or sp_album, "uri or sp_album is required"
 
         self._session = session
 
         if uri is not None:
             album = spotify.Link(self._session, uri=uri).as_album()
             if album is None:
-                raise ValueError('Failed to get album from Spotify URI: %r' % uri)
+                raise ValueError("Failed to get album from Spotify URI: %r" % uri)
             sp_album = album._sp_album
             add_ref = True
 
@@ -42,7 +42,7 @@ class Album(object):
         self._sp_album = ffi.gc(sp_album, lib.sp_album_release)
 
     def __repr__(self):
-        return 'Album(%r)' % self.link.uri
+        return "Album(%r)" % self.link.uri
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -205,7 +205,7 @@ class AlbumBrowser(object):
         add_ref=True,
     ):
 
-        assert album or sp_albumbrowse, 'album or sp_albumbrowse is required'
+        assert album or sp_albumbrowse, "album or sp_albumbrowse is required"
 
         self._session = session
         self.loaded_event = threading.Event()
@@ -228,9 +228,9 @@ class AlbumBrowser(object):
 
     def __repr__(self):
         if self.is_loaded:
-            return 'AlbumBrowser(%r)' % self.album.link.uri
+            return "AlbumBrowser(%r)" % self.album.link.uri
         else:
-            return 'AlbumBrowser(<not loaded>)'
+            return "AlbumBrowser(<not loaded>)"
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -365,13 +365,13 @@ class AlbumBrowser(object):
         return utils.to_unicode(lib.sp_albumbrowse_review(self._sp_albumbrowse))
 
 
-@ffi.callback('void(sp_albumbrowse *, void *)')
+@ffi.callback("void(sp_albumbrowse *, void *)")
 @serialized
 def _albumbrowse_complete_callback(sp_albumbrowse, handle):
-    logger.debug('albumbrowse_complete_callback called')
+    logger.debug("albumbrowse_complete_callback called")
     if handle == ffi.NULL:
         logger.warning(
-            'pyspotify albumbrowse_complete_callback called without userdata'
+            "pyspotify albumbrowse_complete_callback called without userdata"
         )
         return
     (session, album_browser, callback) = ffi.from_handle(handle)
@@ -381,6 +381,6 @@ def _albumbrowse_complete_callback(sp_albumbrowse, handle):
         callback(album_browser)
 
 
-@utils.make_enum('SP_ALBUMTYPE_')
+@utils.make_enum("SP_ALBUMTYPE_")
 class AlbumType(utils.IntEnum):
     pass

--- a/spotify/artist.py
+++ b/spotify/artist.py
@@ -34,9 +34,7 @@ class Artist(object):
         if uri is not None:
             artist = spotify.Link(self._session, uri=uri).as_artist()
             if artist is None:
-                raise ValueError(
-                    'Failed to get artist from Spotify URI: %r' % uri
-                )
+                raise ValueError('Failed to get artist from Spotify URI: %r' % uri)
             sp_artist = artist._sp_artist
 
         if add_ref:
@@ -174,9 +172,7 @@ class ArtistBrowser(object):
         add_ref=True,
     ):
 
-        assert (
-            artist or sp_artistbrowse
-        ), 'artist or sp_artistbrowse is required'
+        assert artist or sp_artistbrowse, 'artist or sp_artistbrowse is required'
 
         self._session = session
         self.loaded_event = threading.Event()
@@ -199,9 +195,7 @@ class ArtistBrowser(object):
 
         if add_ref:
             lib.sp_artistbrowse_add_ref(sp_artistbrowse)
-        self._sp_artistbrowse = ffi.gc(
-            sp_artistbrowse, lib.sp_artistbrowse_release
-        )
+        self._sp_artistbrowse = ffi.gc(sp_artistbrowse, lib.sp_artistbrowse_release)
 
     loaded_event = None
     """:class:`threading.Event` that is set when the artist browser is loaded.
@@ -246,9 +240,7 @@ class ArtistBrowser(object):
 
         Check to see if there was problems creating the artist browser.
         """
-        return spotify.ErrorType(
-            lib.sp_artistbrowse_error(self._sp_artistbrowse)
-        )
+        return spotify.ErrorType(lib.sp_artistbrowse_error(self._sp_artistbrowse))
 
     @property
     def backend_request_duration(self):
@@ -260,9 +252,7 @@ class ArtistBrowser(object):
         """
         if not self.is_loaded:
             return None
-        return lib.sp_artistbrowse_backend_request_duration(
-            self._sp_artistbrowse
-        )
+        return lib.sp_artistbrowse_backend_request_duration(self._sp_artistbrowse)
 
     @property
     @serialized
@@ -411,9 +401,7 @@ class ArtistBrowser(object):
         def get_artist(sp_artistbrowse, key):
             return spotify.Artist(
                 self._session,
-                sp_artist=lib.sp_artistbrowse_similar_artist(
-                    sp_artistbrowse, key
-                ),
+                sp_artist=lib.sp_artistbrowse_similar_artist(sp_artistbrowse, key),
                 add_ref=True,
             )
 
@@ -432,9 +420,7 @@ class ArtistBrowser(object):
 
         Will always return an empty string if the artist browser isn't loaded.
         """
-        return utils.to_unicode(
-            lib.sp_artistbrowse_biography(self._sp_artistbrowse)
-        )
+        return utils.to_unicode(lib.sp_artistbrowse_biography(self._sp_artistbrowse))
 
 
 @ffi.callback('void(sp_artistbrowse *, void *)')

--- a/spotify/artist.py
+++ b/spotify/artist.py
@@ -6,7 +6,6 @@ import threading
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-
 __all__ = ['Artist', 'ArtistBrowser', 'ArtistBrowserType']
 
 logger = logging.getLogger(__name__)

--- a/spotify/artist.py
+++ b/spotify/artist.py
@@ -6,7 +6,7 @@ import threading
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-__all__ = ['Artist', 'ArtistBrowser', 'ArtistBrowserType']
+__all__ = ["Artist", "ArtistBrowser", "ArtistBrowserType"]
 
 logger = logging.getLogger(__name__)
 
@@ -27,14 +27,14 @@ class Artist(object):
     """
 
     def __init__(self, session, uri=None, sp_artist=None, add_ref=True):
-        assert uri or sp_artist, 'uri or sp_artist is required'
+        assert uri or sp_artist, "uri or sp_artist is required"
 
         self._session = session
 
         if uri is not None:
             artist = spotify.Link(self._session, uri=uri).as_artist()
             if artist is None:
-                raise ValueError('Failed to get artist from Spotify URI: %r' % uri)
+                raise ValueError("Failed to get artist from Spotify URI: %r" % uri)
             sp_artist = artist._sp_artist
 
         if add_ref:
@@ -42,7 +42,7 @@ class Artist(object):
         self._sp_artist = ffi.gc(sp_artist, lib.sp_artist_release)
 
     def __repr__(self):
-        return 'Artist(%r)' % self.link.uri
+        return "Artist(%r)" % self.link.uri
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -172,7 +172,7 @@ class ArtistBrowser(object):
         add_ref=True,
     ):
 
-        assert artist or sp_artistbrowse, 'artist or sp_artistbrowse is required'
+        assert artist or sp_artistbrowse, "artist or sp_artistbrowse is required"
 
         self._session = session
         self.loaded_event = threading.Event()
@@ -203,9 +203,9 @@ class ArtistBrowser(object):
 
     def __repr__(self):
         if self.is_loaded:
-            return 'ArtistBrowser(%r)' % self.artist.link.uri
+            return "ArtistBrowser(%r)" % self.artist.link.uri
         else:
-            return 'ArtistBrowser(<not loaded>)'
+            return "ArtistBrowser(<not loaded>)"
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -423,13 +423,13 @@ class ArtistBrowser(object):
         return utils.to_unicode(lib.sp_artistbrowse_biography(self._sp_artistbrowse))
 
 
-@ffi.callback('void(sp_artistbrowse *, void *)')
+@ffi.callback("void(sp_artistbrowse *, void *)")
 @serialized
 def _artistbrowse_complete_callback(sp_artistbrowse, handle):
-    logger.debug('artistbrowse_complete_callback called')
+    logger.debug("artistbrowse_complete_callback called")
     if handle == ffi.NULL:
         logger.warning(
-            'pyspotify artistbrowse_complete_callback called without userdata'
+            "pyspotify artistbrowse_complete_callback called without userdata"
         )
         return
     (session, artist_browser, callback) = ffi.from_handle(handle)
@@ -439,6 +439,6 @@ def _artistbrowse_complete_callback(sp_artistbrowse, handle):
         callback(artist_browser)
 
 
-@utils.make_enum('SP_ARTISTBROWSE_')
+@utils.make_enum("SP_ARTISTBROWSE_")
 class ArtistBrowserType(utils.IntEnum):
     pass

--- a/spotify/audio.py
+++ b/spotify/audio.py
@@ -4,11 +4,11 @@ import collections
 
 from spotify import utils
 
-__all__ = ['AudioBufferStats', 'AudioFormat', 'Bitrate', 'SampleType']
+__all__ = ["AudioBufferStats", "AudioFormat", "Bitrate", "SampleType"]
 
 
 class AudioBufferStats(
-    collections.namedtuple('AudioBufferStats', ['samples', 'stutter'])
+    collections.namedtuple("AudioBufferStats", ["samples", "stutter"])
 ):
 
     """Stats about the application's audio buffers."""
@@ -16,12 +16,12 @@ class AudioBufferStats(
     pass
 
 
-@utils.make_enum('SP_BITRATE_', 'BITRATE_')
+@utils.make_enum("SP_BITRATE_", "BITRATE_")
 class Bitrate(utils.IntEnum):
     pass
 
 
-@utils.make_enum('SP_SAMPLETYPE_')
+@utils.make_enum("SP_SAMPLETYPE_")
 class SampleType(utils.IntEnum):
     pass
 
@@ -59,4 +59,4 @@ class AudioFormat(object):
         if self.sample_type == SampleType.INT16_NATIVE_ENDIAN:
             return 2 * self.channels
         else:
-            raise ValueError('Unknown sample type: %d', self.sample_type)
+            raise ValueError("Unknown sample type: %d", self.sample_type)

--- a/spotify/audio.py
+++ b/spotify/audio.py
@@ -4,7 +4,6 @@ import collections
 
 from spotify import utils
 
-
 __all__ = ['AudioBufferStats', 'AudioFormat', 'Bitrate', 'SampleType']
 
 

--- a/spotify/compat.py
+++ b/spotify/compat.py
@@ -1,6 +1,5 @@
 import sys
 
-
 PY2 = sys.version_info[0] == 2
 
 if PY2:  # pragma: no branch

--- a/spotify/config.py
+++ b/spotify/config.py
@@ -303,9 +303,7 @@ class Config(object):
         proxy_password_ptr = spotify.ffi.addressof(
             self._sp_session_config, 'proxy_password'
         )
-        tracefile_ptr = spotify.ffi.addressof(
-            self._sp_session_config, 'tracefile'
-        )
+        tracefile_ptr = spotify.ffi.addressof(self._sp_session_config, 'tracefile')
         if tracefile_ptr - proxy_password_ptr != 2:
             return None
         return proxy_password_ptr + 1

--- a/spotify/config.py
+++ b/spotify/config.py
@@ -4,7 +4,7 @@ import spotify
 from spotify import ffi, utils
 from spotify.session import _SessionCallbacks
 
-__all__ = ['Config']
+__all__ = ["Config"]
 
 
 class Config(object):
@@ -23,14 +23,14 @@ class Config(object):
     def __init__(self):
         self._sp_session_callbacks = _SessionCallbacks.get_struct()
         self._sp_session_config = ffi.new(
-            'sp_session_config *', {'callbacks': self._sp_session_callbacks}
+            "sp_session_config *", {"callbacks": self._sp_session_callbacks}
         )
 
         # Defaults
         self.api_version = spotify.get_libspotify_api_version()
-        self.cache_location = b'tmp'
-        self.settings_location = b'tmp'
-        self.user_agent = 'pyspotify %s' % spotify.__version__
+        self.cache_location = b"tmp"
+        self.settings_location = b"tmp"
+        self.user_agent = "pyspotify %s" % spotify.__version__
         self.compress_playlists = False
         self.dont_save_metadata_for_playlists = False
         self.initially_unload_playlists = False
@@ -70,7 +70,7 @@ class Config(object):
     def cache_location(self, value):
         # NOTE libspotify segfaults if cache_location is set to NULL, thus we
         # convert None to empty string.
-        self._cache_location = utils.to_char('' if value is None else value)
+        self._cache_location = utils.to_char("" if value is None else value)
         self._sp_session_config.cache_location = self._cache_location
 
     @property
@@ -87,7 +87,7 @@ class Config(object):
 
     @settings_location.setter
     def settings_location(self, value):
-        self._settings_location = utils.to_char('' if value is None else value)
+        self._settings_location = utils.to_char("" if value is None else value)
         self._sp_session_config.settings_location = self._settings_location
 
     @property
@@ -99,7 +99,7 @@ class Config(object):
         the file into :attr:`application_key`.
         """
         return utils.to_bytes_or_none(
-            ffi.cast('char *', self._sp_session_config.application_key)
+            ffi.cast("char *", self._sp_session_config.application_key)
         )
 
     @application_key.setter
@@ -109,16 +109,16 @@ class Config(object):
         else:
             size = len(value)
         assert size in (0, 321), (
-            'Invalid application key; expected 321 bytes, got %d bytes' % size
+            "Invalid application key; expected 321 bytes, got %d bytes" % size
         )
 
         self._application_key = utils.to_char_or_null(value)
         self._sp_session_config.application_key = ffi.cast(
-            'void *', self._application_key
+            "void *", self._application_key
         )
         self._sp_session_config.application_key_size = size
 
-    def load_application_key_file(self, filename=b'spotify_appkey.key'):
+    def load_application_key_file(self, filename=b"spotify_appkey.key"):
         """Load your libspotify application key file.
 
         If called without arguments, it tries to read ``spotify_appkey.key``
@@ -128,7 +128,7 @@ class Config(object):
         file must be a binary key file, not the C code key file that can be
         compiled into an application.
         """
-        with open(filename, 'rb') as fh:
+        with open(filename, "rb") as fh:
             self.application_key = fh.read()
 
     @property
@@ -141,7 +141,7 @@ class Config(object):
 
     @user_agent.setter
     def user_agent(self, value):
-        self._user_agent = utils.to_char('' if value is None else value)
+        self._user_agent = utils.to_char("" if value is None else value)
         self._sp_session_config.user_agent = self._user_agent
 
     @property
@@ -223,7 +223,7 @@ class Config(object):
     def proxy(self, value):
         # NOTE libspotify reuses cached values from previous sessions if this
         # is set to NULL, thus we convert None to empty string.
-        self._proxy = utils.to_char_or_null('' if value is None else value)
+        self._proxy = utils.to_char_or_null("" if value is None else value)
         self._sp_session_config.proxy = self._proxy
 
     @property
@@ -238,7 +238,7 @@ class Config(object):
     def proxy_username(self, value):
         # NOTE libspotify reuses cached values from previous sessions if this
         # is set to NULL, thus we convert None to empty string.
-        self._proxy_username = utils.to_char('' if value is None else value)
+        self._proxy_username = utils.to_char("" if value is None else value)
         self._sp_session_config.proxy_username = self._proxy_username
 
     @property
@@ -253,7 +253,7 @@ class Config(object):
     def proxy_password(self, value):
         # NOTE libspotify reuses cached values from previous sessions if this
         # is set to NULL, thus we convert None to empty string.
-        self._proxy_password = utils.to_char('' if value is None else value)
+        self._proxy_password = utils.to_char("" if value is None else value)
         self._sp_session_config.proxy_password = self._proxy_password
 
     @property
@@ -301,9 +301,9 @@ class Config(object):
         # struct only if the SP_WITH_CURL macro is defined, ref. the
         # sp_session_create example in the libspotify docs.
         proxy_password_ptr = spotify.ffi.addressof(
-            self._sp_session_config, 'proxy_password'
+            self._sp_session_config, "proxy_password"
         )
-        tracefile_ptr = spotify.ffi.addressof(self._sp_session_config, 'tracefile')
+        tracefile_ptr = spotify.ffi.addressof(self._sp_session_config, "tracefile")
         if tracefile_ptr - proxy_password_ptr != 2:
             return None
         return proxy_password_ptr + 1

--- a/spotify/connection.py
+++ b/spotify/connection.py
@@ -6,7 +6,7 @@ import operator
 import spotify
 from spotify import lib, utils
 
-__all__ = ['ConnectionRule', 'ConnectionState', 'ConnectionType']
+__all__ = ["ConnectionRule", "ConnectionState", "ConnectionType"]
 
 
 class Connection(object):
@@ -147,16 +147,16 @@ class Connection(object):
         )
 
 
-@utils.make_enum('SP_CONNECTION_RULE_')
+@utils.make_enum("SP_CONNECTION_RULE_")
 class ConnectionRule(utils.IntEnum):
     pass
 
 
-@utils.make_enum('SP_CONNECTION_STATE_')
+@utils.make_enum("SP_CONNECTION_STATE_")
 class ConnectionState(utils.IntEnum):
     pass
 
 
-@utils.make_enum('SP_CONNECTION_TYPE_')
+@utils.make_enum("SP_CONNECTION_TYPE_")
 class ConnectionType(utils.IntEnum):
     pass

--- a/spotify/connection.py
+++ b/spotify/connection.py
@@ -143,9 +143,7 @@ class Connection(object):
             rules.append(spotify.ConnectionRule.ALLOW_SYNC_OVER_MOBILE)
         rules = functools.reduce(operator.or_, rules, 0)
         spotify.Error.maybe_raise(
-            lib.sp_session_set_connection_rules(
-                self._session._sp_session, rules
-            )
+            lib.sp_session_set_connection_rules(self._session._sp_session, rules)
         )
 
 

--- a/spotify/connection.py
+++ b/spotify/connection.py
@@ -6,7 +6,6 @@ import operator
 import spotify
 from spotify import lib, utils
 
-
 __all__ = ['ConnectionRule', 'ConnectionState', 'ConnectionType']
 
 

--- a/spotify/error.py
+++ b/spotify/error.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from spotify import lib, serialized, utils
 
-__all__ = ['Error', 'ErrorType', 'LibError', 'Timeout']
+__all__ = ["Error", "ErrorType", "LibError", "Timeout"]
 
 
 class Error(Exception):
@@ -25,7 +25,7 @@ class Error(Exception):
             raise LibError(error_type)
 
 
-@utils.make_enum('SP_ERROR_')
+@utils.make_enum("SP_ERROR_")
 class ErrorType(utils.IntEnum):
     pass
 
@@ -50,15 +50,15 @@ class LibError(Error):
         super(Error, self).__init__(message)
 
     def __eq__(self, other):
-        return self.error_type == getattr(other, 'error_type', None)
+        return self.error_type == getattr(other, "error_type", None)
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
 
 for attr in dir(lib):
-    if attr.startswith('SP_ERROR_'):
-        name = attr.replace('SP_ERROR_', '')
+    if attr.startswith("SP_ERROR_"):
+        name = attr.replace("SP_ERROR_", "")
         error_no = getattr(lib, attr)
         setattr(LibError, name, LibError(error_no))
 
@@ -69,5 +69,5 @@ class Timeout(Error):
     timeout."""
 
     def __init__(self, timeout):
-        message = 'Operation did not complete in %.3fs' % timeout
+        message = "Operation did not complete in %.3fs" % timeout
         super(Timeout, self).__init__(message)

--- a/spotify/error.py
+++ b/spotify/error.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 from spotify import lib, serialized, utils
 
-
 __all__ = ['Error', 'ErrorType', 'LibError', 'Timeout']
 
 

--- a/spotify/eventloop.py
+++ b/spotify/eventloop.py
@@ -12,7 +12,6 @@ except ImportError:
 
 import spotify
 
-
 __all__ = ['EventLoop']
 
 logger = logging.getLogger(__name__)

--- a/spotify/eventloop.py
+++ b/spotify/eventloop.py
@@ -12,7 +12,7 @@ except ImportError:
 
 import spotify
 
-__all__ = ['EventLoop']
+__all__ = ["EventLoop"]
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ class EventLoop(threading.Thread):
     """
 
     daemon = True
-    name = 'SpotifyEventLoop'
+    name = "SpotifyEventLoop"
 
     def __init__(self, session):
         threading.Thread.__init__(self)
@@ -72,19 +72,19 @@ class EventLoop(threading.Thread):
         )
 
     def run(self):
-        logger.debug('Spotify event loop started')
+        logger.debug("Spotify event loop started")
         timeout = self._session.process_events() / 1000.0
         while self._runnable:
             try:
-                logger.debug('Waiting %.3fs for new events', timeout)
+                logger.debug("Waiting %.3fs for new events", timeout)
                 self._queue.get(timeout=timeout)
             except queue.Empty:
-                logger.debug('Timeout reached; processing events')
+                logger.debug("Timeout reached; processing events")
             else:
-                logger.debug('Notification received; processing events')
+                logger.debug("Notification received; processing events")
             finally:
                 timeout = self._session.process_events() / 1000.0
-        logger.debug('Spotify event loop stopped')
+        logger.debug("Spotify event loop stopped")
 
     def _on_notify_main_thread(self, session):
         # WARNING: This event listener is called from an internal libspotify
@@ -93,5 +93,5 @@ class EventLoop(threading.Thread):
             self._queue.put_nowait(1)
         except queue.Full:
             logger.warning(
-                'pyspotify event loop queue full; dropped notification event'
+                "pyspotify event loop queue full; dropped notification event"
             )

--- a/spotify/image.py
+++ b/spotify/image.py
@@ -7,7 +7,6 @@ import threading
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-
 __all__ = ['Image', 'ImageFormat', 'ImageSize']
 
 logger = logging.getLogger(__name__)

--- a/spotify/image.py
+++ b/spotify/image.py
@@ -7,7 +7,7 @@ import threading
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-__all__ = ['Image', 'ImageFormat', 'ImageSize']
+__all__ = ["Image", "ImageFormat", "ImageSize"]
 
 logger = logging.getLogger(__name__)
 
@@ -34,14 +34,14 @@ class Image(object):
 
     def __init__(self, session, uri=None, sp_image=None, add_ref=True, callback=None):
 
-        assert uri or sp_image, 'uri or sp_image is required'
+        assert uri or sp_image, "uri or sp_image is required"
 
         self._session = session
 
         if uri is not None:
             image = spotify.Link(self._session, uri=uri).as_image()
             if image is None:
-                raise ValueError('Failed to get image from Spotify URI: %r' % uri)
+                raise ValueError("Failed to get image from Spotify URI: %r" % uri)
             sp_image = image._sp_image
             add_ref = True
 
@@ -58,7 +58,7 @@ class Image(object):
         )
 
     def __repr__(self):
-        return 'Image(%r)' % self.link.uri
+        return "Image(%r)" % self.link.uri
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -117,11 +117,11 @@ class Image(object):
         """
         if not self.is_loaded:
             return None
-        data_size_ptr = ffi.new('size_t *')
+        data_size_ptr = ffi.new("size_t *")
         data = lib.sp_image_data(self._sp_image, data_size_ptr)
         buffer_ = ffi.buffer(data, data_size_ptr[0])
         data_bytes = buffer_[:]
-        assert len(data_bytes) == data_size_ptr[0], '%r == %r' % (
+        assert len(data_bytes) == data_size_ptr[0], "%r == %r" % (
             len(data_bytes),
             data_size_ptr[0],
         )
@@ -136,9 +136,9 @@ class Image(object):
         if not self.is_loaded:
             return None
         if self.format is not ImageFormat.JPEG:
-            raise ValueError('Unknown image format: %r' % self.format)
-        return 'data:image/jpeg;base64,%s' % (
-            base64.b64encode(self.data).decode('ascii')
+            raise ValueError("Unknown image format: %r" % self.format)
+        return "data:image/jpeg;base64,%s" % (
+            base64.b64encode(self.data).decode("ascii")
         )
 
     @property
@@ -151,12 +151,12 @@ class Image(object):
         )
 
 
-@ffi.callback('void(sp_image *, void *)')
+@ffi.callback("void(sp_image *, void *)")
 @serialized
 def _image_load_callback(sp_image, handle):
-    logger.debug('image_load_callback called')
+    logger.debug("image_load_callback called")
     if handle == ffi.NULL:
-        logger.warning('pyspotify image_load_callback called without userdata')
+        logger.warning("pyspotify image_load_callback called without userdata")
         return
     (session, image, callback) = ffi.from_handle(handle)
     session._callback_handles.remove(handle)
@@ -169,11 +169,11 @@ def _image_load_callback(sp_image, handle):
     lib.sp_image_remove_load_callback(sp_image, _image_load_callback, handle)
 
 
-@utils.make_enum('SP_IMAGE_FORMAT_')
+@utils.make_enum("SP_IMAGE_FORMAT_")
 class ImageFormat(utils.IntEnum):
     pass
 
 
-@utils.make_enum('SP_IMAGE_SIZE_')
+@utils.make_enum("SP_IMAGE_SIZE_")
 class ImageSize(utils.IntEnum):
     pass

--- a/spotify/image.py
+++ b/spotify/image.py
@@ -32,9 +32,7 @@ class Image(object):
     the image is done loading.
     """
 
-    def __init__(
-        self, session, uri=None, sp_image=None, add_ref=True, callback=None
-    ):
+    def __init__(self, session, uri=None, sp_image=None, add_ref=True, callback=None):
 
         assert uri or sp_image, 'uri or sp_image is required'
 
@@ -43,9 +41,7 @@ class Image(object):
         if uri is not None:
             image = spotify.Link(self._session, uri=uri).as_image()
             if image is None:
-                raise ValueError(
-                    'Failed to get image from Spotify URI: %r' % uri
-                )
+                raise ValueError('Failed to get image from Spotify URI: %r' % uri)
             sp_image = image._sp_image
             add_ref = True
 
@@ -58,9 +54,7 @@ class Image(object):
         handle = ffi.new_handle((self._session, self, callback))
         self._session._callback_handles.add(handle)
         spotify.Error.maybe_raise(
-            lib.sp_image_add_load_callback(
-                self._sp_image, _image_load_callback, handle
-            )
+            lib.sp_image_add_load_callback(self._sp_image, _image_load_callback, handle)
         )
 
     def __repr__(self):

--- a/spotify/inbox.py
+++ b/spotify/inbox.py
@@ -6,7 +6,7 @@ import threading
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-__all__ = ['InboxPostResult']
+__all__ = ["InboxPostResult"]
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ class InboxPostResult(object):
         session,
         canonical_username=None,
         tracks=None,
-        message='',
+        message="",
         callback=None,
         sp_inbox=None,
         add_ref=True,
@@ -29,7 +29,7 @@ class InboxPostResult(object):
 
         assert (
             canonical_username and tracks or sp_inbox
-        ), 'canonical_username and tracks, or sp_inbox, is required'
+        ), "canonical_username and tracks, or sp_inbox, is required"
 
         self._session = session
         self.loaded_event = threading.Event()
@@ -57,7 +57,7 @@ class InboxPostResult(object):
             add_ref = True
 
             if sp_inbox == ffi.NULL:
-                raise spotify.Error('Inbox post request failed to initialize')
+                raise spotify.Error("Inbox post request failed to initialize")
 
         if add_ref:
             lib.sp_inbox_add_ref(sp_inbox)
@@ -70,9 +70,9 @@ class InboxPostResult(object):
 
     def __repr__(self):
         if not self.loaded_event.is_set():
-            return 'InboxPostResult(<pending>)'
+            return "InboxPostResult(<pending>)"
         else:
-            return 'InboxPostResult(%s)' % self.error._name
+            return "InboxPostResult(%s)" % self.error._name
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -95,12 +95,12 @@ class InboxPostResult(object):
         return spotify.ErrorType(lib.sp_inbox_error(self._sp_inbox))
 
 
-@ffi.callback('void(sp_inbox *, void *)')
+@ffi.callback("void(sp_inbox *, void *)")
 @serialized
 def _inboxpost_complete_callback(sp_inbox, handle):
-    logger.debug('inboxpost_complete_callback called')
+    logger.debug("inboxpost_complete_callback called")
     if handle == ffi.NULL:
-        logger.warning('pyspotify inboxpost_complete_callback called without userdata')
+        logger.warning("pyspotify inboxpost_complete_callback called without userdata")
         return
     (session, inbox_post_result, callback) = ffi.from_handle(handle)
     session._callback_handles.remove(handle)

--- a/spotify/inbox.py
+++ b/spotify/inbox.py
@@ -6,7 +6,6 @@ import threading
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-
 __all__ = ['InboxPostResult']
 
 logger = logging.getLogger(__name__)

--- a/spotify/inbox.py
+++ b/spotify/inbox.py
@@ -100,9 +100,7 @@ class InboxPostResult(object):
 def _inboxpost_complete_callback(sp_inbox, handle):
     logger.debug('inboxpost_complete_callback called')
     if handle == ffi.NULL:
-        logger.warning(
-            'pyspotify inboxpost_complete_callback called without userdata'
-        )
+        logger.warning('pyspotify inboxpost_complete_callback called without userdata')
         return
     (session, inbox_post_result, callback) = ffi.from_handle(handle)
     session._callback_handles.remove(handle)

--- a/spotify/link.py
+++ b/spotify/link.py
@@ -67,9 +67,7 @@ class Link(object):
             )
             add_ref = False
             if sp_link == ffi.NULL:
-                raise ValueError(
-                    'Failed to get link from Spotify URI: %r' % uri
-                )
+                raise ValueError('Failed to get link from Spotify URI: %r' % uri)
 
         if add_ref:
             lib.sp_link_add_ref(sp_link)
@@ -105,9 +103,7 @@ class Link(object):
     @property
     def uri(self):
         """The link's Spotify URI."""
-        return utils.get_with_growing_buffer(
-            lib.sp_link_as_string, self._sp_link
-        )
+        return utils.get_with_growing_buffer(lib.sp_link_as_string, self._sp_link)
 
     @property
     def url(self):
@@ -158,9 +154,7 @@ class Link(object):
         sp_playlist = self._as_sp_playlist()
         if sp_playlist is None:
             return None
-        return spotify.Playlist._cached(
-            self._session, sp_playlist, add_ref=False
-        )
+        return spotify.Playlist._cached(self._session, sp_playlist, add_ref=False)
 
     def _as_sp_playlist(self):
         sp_playlist = None

--- a/spotify/link.py
+++ b/spotify/link.py
@@ -12,7 +12,7 @@ except ImportError:
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-__all__ = ['Link', 'LinkType']
+__all__ = ["Link", "LinkType"]
 
 
 class Link(object):
@@ -57,7 +57,7 @@ class Link(object):
     """
 
     def __init__(self, session, uri=None, sp_link=None, add_ref=True):
-        assert uri or sp_link, 'uri or sp_link is required'
+        assert uri or sp_link, "uri or sp_link is required"
 
         self._session = session
 
@@ -67,7 +67,7 @@ class Link(object):
             )
             add_ref = False
             if sp_link == ffi.NULL:
-                raise ValueError('Failed to get link from Spotify URI: %r' % uri)
+                raise ValueError("Failed to get link from Spotify URI: %r" % uri)
 
         if add_ref:
             lib.sp_link_add_ref(sp_link)
@@ -75,15 +75,15 @@ class Link(object):
 
     @staticmethod
     def _normalize_uri(uri):
-        if uri.startswith('spotify:'):
+        if uri.startswith("spotify:"):
             return uri
         parsed = urlparse(uri)
-        if parsed.netloc not in ('open.spotify.com', 'play.spotify.com'):
+        if parsed.netloc not in ("open.spotify.com", "play.spotify.com"):
             return uri
-        return 'spotify%s' % parsed.path.strip().replace('/', ':')
+        return "spotify%s" % parsed.path.strip().replace("/", ":")
 
     def __repr__(self):
-        return 'Link(%r)' % self.uri
+        return "Link(%r)" % self.uri
 
     def __str__(self):
         return self.uri
@@ -108,8 +108,8 @@ class Link(object):
     @property
     def url(self):
         """The link's HTTP URL."""
-        return 'https://open.spotify.com%s' % (
-            self.uri[len('spotify') :].replace(':', '/')
+        return "https://open.spotify.com%s" % (
+            self.uri[len("spotify") :].replace(":", "/")
         )
 
     @property
@@ -127,7 +127,7 @@ class Link(object):
 
     def as_track_offset(self):
         """Get the track offset in milliseconds from the link."""
-        offset = ffi.new('int *')
+        offset = ffi.new("int *")
         sp_track = lib.sp_link_as_track_and_offset(self._sp_link, offset)
         if sp_track == ffi.NULL:
             return None
@@ -163,7 +163,7 @@ class Link(object):
                 self._session._sp_session, self._sp_link
             )
         elif self.type == LinkType.STARRED:
-            matches = re.match(r'^spotify:user:([^:]+):starred$', self.uri)
+            matches = re.match(r"^spotify:user:([^:]+):starred$", self.uri)
             if matches:
                 username = matches.group(1)
                 sp_playlist = lib.sp_session_starred_for_user_create(
@@ -200,6 +200,6 @@ class Link(object):
         )
 
 
-@utils.make_enum('SP_LINKTYPE_')
+@utils.make_enum("SP_LINKTYPE_")
 class LinkType(utils.IntEnum):
     pass

--- a/spotify/offline.py
+++ b/spotify/offline.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import spotify
 from spotify import ffi, lib
 
-__all__ = ['OfflineSyncStatus']
+__all__ = ["OfflineSyncStatus"]
 
 
 class Offline(object):
@@ -37,7 +37,7 @@ class Offline(object):
         The :attr:`~SessionEvent.OFFLINE_STATUS_UPDATED` event is emitted on
         the session object when this is updated.
         """
-        sp_offline_sync_status = ffi.new('sp_offline_sync_status *')
+        sp_offline_sync_status = ffi.new("sp_offline_sync_status *")
         syncing = lib.sp_offline_sync_get_status(
             self._session._sp_session, sp_offline_sync_status
         )

--- a/spotify/offline.py
+++ b/spotify/offline.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import spotify
 from spotify import ffi, lib
 
-
 __all__ = ['OfflineSyncStatus']
 
 

--- a/spotify/player.py
+++ b/spotify/player.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import spotify
 from spotify import lib
 
-
 __all__ = ['PlayerState']
 
 

--- a/spotify/player.py
+++ b/spotify/player.py
@@ -40,9 +40,7 @@ class Player(object):
     def load(self, track):
         """Load :class:`Track` for playback."""
         spotify.Error.maybe_raise(
-            lib.sp_session_player_load(
-                self._session._sp_session, track._sp_track
-            )
+            lib.sp_session_player_load(self._session._sp_session, track._sp_track)
         )
         self.state = PlayerState.LOADED
 
@@ -89,7 +87,5 @@ class Player(object):
         playing it.
         """
         spotify.Error.maybe_raise(
-            lib.sp_session_player_prefetch(
-                self._session._sp_session, track._sp_track
-            )
+            lib.sp_session_player_prefetch(self._session._sp_session, track._sp_track)
         )

--- a/spotify/player.py
+++ b/spotify/player.py
@@ -3,14 +3,14 @@ from __future__ import unicode_literals
 import spotify
 from spotify import lib
 
-__all__ = ['PlayerState']
+__all__ = ["PlayerState"]
 
 
 class PlayerState(object):
-    UNLOADED = 'unloaded'
-    LOADED = 'loaded'
-    PLAYING = 'playing'
-    PAUSED = 'paused'
+    UNLOADED = "unloaded"
+    LOADED = "loaded"
+    PLAYING = "playing"
+    PAUSED = "paused"
 
 
 class Player(object):

--- a/spotify/playlist.py
+++ b/spotify/playlist.py
@@ -5,7 +5,6 @@ import logging
 import spotify
 from spotify import compat, ffi, lib, serialized, utils
 
-
 __all__ = ['Playlist', 'PlaylistEvent', 'PlaylistOfflineStatus']
 
 logger = logging.getLogger(__name__)

--- a/spotify/playlist.py
+++ b/spotify/playlist.py
@@ -5,7 +5,7 @@ import logging
 import spotify
 from spotify import compat, ffi, lib, serialized, utils
 
-__all__ = ['Playlist', 'PlaylistEvent', 'PlaylistOfflineStatus']
+__all__ = ["Playlist", "PlaylistEvent", "PlaylistOfflineStatus"]
 
 logger = logging.getLogger(__name__)
 
@@ -46,14 +46,14 @@ class Playlist(utils.EventEmitter):
     def __init__(self, session, uri=None, sp_playlist=None, add_ref=True):
         super(Playlist, self).__init__()
 
-        assert uri or sp_playlist, 'uri or sp_playlist is required'
+        assert uri or sp_playlist, "uri or sp_playlist is required"
 
         self._session = session
 
         if uri is not None:
             sp_playlist = spotify.Link(self._session, uri)._as_sp_playlist()
             if sp_playlist is None:
-                raise spotify.Error('Failed to get playlist from Spotify URI: %r' % uri)
+                raise spotify.Error("Failed to get playlist from Spotify URI: %r" % uri)
             session._cache[sp_playlist] = self
             add_ref = False
 
@@ -68,9 +68,9 @@ class Playlist(utils.EventEmitter):
         self._lib = lib
 
     def __del__(self):
-        if not hasattr(self, '_lib'):
+        if not hasattr(self, "_lib"):
             return
-        if getattr(self, '_sp_playlist_callbacks', None) is None:
+        if getattr(self, "_sp_playlist_callbacks", None) is None:
             return
         self._lib.sp_playlist_remove_callbacks(
             self._sp_playlist, self._sp_playlist_callbacks, ffi.NULL
@@ -78,11 +78,11 @@ class Playlist(utils.EventEmitter):
 
     def __repr__(self):
         if not self.is_loaded:
-            return 'Playlist(<not loaded>)'
+            return "Playlist(<not loaded>)"
         try:
-            return 'Playlist(%r)' % self.link.uri
+            return "Playlist(%r)" % self.link.uri
         except spotify.Error as exc:
-            return 'Playlist(<error: %s>)' % exc
+            return "Playlist(<error: %s>)" % exc
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -212,7 +212,7 @@ class Playlist(utils.EventEmitter):
         Will always return :class:`None` if the playlist isn't loaded or the
         playlist has no image.
         """
-        image_id = ffi.new('char[20]')
+        image_id = ffi.new("char[20]")
         has_image = bool(lib.sp_playlist_get_image(self._sp_playlist, image_id))
         if not has_image:
             return None
@@ -310,7 +310,7 @@ class Playlist(utils.EventEmitter):
         # The ``subscribers`` field is ``char *[1]`` according to the struct,
         # so we must cast it to ``char **`` to be able to access more than the
         # first subscriber.
-        subscribers = ffi.cast('char **', sp_subscribers.subscribers)
+        subscribers = ffi.cast("char **", sp_subscribers.subscribers)
         usernames = []
         for i in range(sp_subscribers.count):
             usernames.append(utils.to_unicode(subscribers[i]))
@@ -396,16 +396,16 @@ class Playlist(utils.EventEmitter):
     def link(self):
         """A :class:`Link` to the playlist."""
         if not self.is_loaded:
-            raise spotify.Error('The playlist must be loaded to create a link')
+            raise spotify.Error("The playlist must be loaded to create a link")
         sp_link = lib.sp_link_create_from_playlist(self._sp_playlist)
         if sp_link == ffi.NULL:
             if not self.is_in_ram:
                 raise spotify.Error(
-                    'The playlist must have been in RAM to create a link'
+                    "The playlist must have been in RAM to create a link"
                 )
             # XXX Figure out why we can still get NULL here even if
             # the playlist is both loaded and in RAM.
-            raise spotify.Error('Failed to get link from Spotify playlist')
+            raise spotify.Error("Failed to get link from Spotify playlist")
         return spotify.Link(self._session, sp_link=sp_link, add_ref=False)
 
     @serialized
@@ -457,7 +457,7 @@ class PlaylistEvent(object):
     functions just to log that they're called.
     """
 
-    TRACKS_ADDED = 'tracks_added'
+    TRACKS_ADDED = "tracks_added"
     """Called when one or more tracks have been added to the playlist.
 
     :param playlist: the playlist
@@ -468,7 +468,7 @@ class PlaylistEvent(object):
     :type index: int
     """
 
-    TRACKS_REMOVED = 'tracks_removed'
+    TRACKS_REMOVED = "tracks_removed"
     """Called when one or more tracks have been removed from the playlist.
 
     :param playlist: the playlist
@@ -477,7 +477,7 @@ class PlaylistEvent(object):
     :type indexes: list of ints
     """
 
-    TRACKS_MOVED = 'tracks_moved'
+    TRACKS_MOVED = "tracks_moved"
     """Called when one or more tracks have been moved within a playlist.
 
     :param playlist: the playlist
@@ -488,14 +488,14 @@ class PlaylistEvent(object):
     :type new_index: int
     """
 
-    PLAYLIST_RENAMED = 'playlist_renamed'
+    PLAYLIST_RENAMED = "playlist_renamed"
     """Called when the playlist has been renamed.
 
     :param playlist: the playlist
     :type playlist: :class:`Playlist`
     """
 
-    PLAYLIST_STATE_CHANGED = 'playlist_state_changed'
+    PLAYLIST_STATE_CHANGED = "playlist_state_changed"
     """Called when the state changed for a playlist.
 
     There are three states that trigger this callback:
@@ -511,7 +511,7 @@ class PlaylistEvent(object):
     :type playlist: :class:`Playlist`
     """
 
-    PLAYLIST_UPDATE_IN_PROGRESS = 'playlist_update_in_progress'
+    PLAYLIST_UPDATE_IN_PROGRESS = "playlist_update_in_progress"
     """Called when a playlist is updating or is done updating.
 
     This is called before and after a series of changes are applied to the
@@ -524,7 +524,7 @@ class PlaylistEvent(object):
     :type done: bool
     """
 
-    PLAYLIST_METADATA_UPDATED = 'playlist_metadata_updated'
+    PLAYLIST_METADATA_UPDATED = "playlist_metadata_updated"
     """Called when metadata for one or more tracks in the playlist have been
     updated.
 
@@ -532,7 +532,7 @@ class PlaylistEvent(object):
     :type playlist: :class:`Playlist`
     """
 
-    TRACK_CREATED_CHANGED = 'track_created_changed'
+    TRACK_CREATED_CHANGED = "track_created_changed"
     """Called when the create time and/or creator for a playlist entry changes.
 
     :param playlist: the playlist
@@ -545,7 +545,7 @@ class PlaylistEvent(object):
     :type time: int
     """
 
-    TRACK_SEEN_CHANGED = 'track_seen_changed'
+    TRACK_SEEN_CHANGED = "track_seen_changed"
     """Called when the seen attribute of a playlist entry changes.
 
     :param playlist: the playlist
@@ -556,7 +556,7 @@ class PlaylistEvent(object):
     :type seen: bool
     """
 
-    DESCRIPTION_CHANGED = 'description_changed'
+    DESCRIPTION_CHANGED = "description_changed"
     """Called when the playlist description has changed.
 
     :param playlist: the playlist
@@ -565,7 +565,7 @@ class PlaylistEvent(object):
     :type description: string
     """
 
-    IMAGE_CHANGED = 'image_changed'
+    IMAGE_CHANGED = "image_changed"
     """Called when the playlist image has changed.
 
     :param playlist: the playlist
@@ -574,7 +574,7 @@ class PlaylistEvent(object):
     :type image: :class:`Image`
     """
 
-    TRACK_MESSAGE_CHANGED = 'track_message_changed'
+    TRACK_MESSAGE_CHANGED = "track_message_changed"
     """Called when the message attribute of a playlist entry changes.
 
     :param playlist: the playlist
@@ -585,7 +585,7 @@ class PlaylistEvent(object):
     :type message: string
     """
 
-    SUBSCRIBERS_CHANGED = 'subscribers_changed'
+    SUBSCRIBERS_CHANGED = "subscribers_changed"
     """Called when playlist subscribers changes, either the count or the
     subscriber names.
 
@@ -598,21 +598,21 @@ class _PlaylistCallbacks(object):
     @classmethod
     def get_struct(cls):
         return ffi.new(
-            'sp_playlist_callbacks *',
+            "sp_playlist_callbacks *",
             {
-                'tracks_added': cls.tracks_added,
-                'tracks_removed': cls.tracks_removed,
-                'tracks_moved': cls.tracks_moved,
-                'playlist_renamed': cls.playlist_renamed,
-                'playlist_state_changed': cls.playlist_state_changed,
-                'playlist_update_in_progress': cls.playlist_update_in_progress,
-                'playlist_metadata_updated': cls.playlist_metadata_updated,
-                'track_created_changed': cls.track_created_changed,
-                'track_seen_changed': cls.track_seen_changed,
-                'description_changed': cls.description_changed,
-                'image_changed': cls.image_changed,
-                'track_message_changed': cls.track_message_changed,
-                'subscribers_changed': cls.subscribers_changed,
+                "tracks_added": cls.tracks_added,
+                "tracks_removed": cls.tracks_removed,
+                "tracks_moved": cls.tracks_moved,
+                "playlist_renamed": cls.playlist_renamed,
+                "playlist_state_changed": cls.playlist_state_changed,
+                "playlist_update_in_progress": cls.playlist_update_in_progress,
+                "playlist_metadata_updated": cls.playlist_metadata_updated,
+                "track_created_changed": cls.track_created_changed,
+                "track_seen_changed": cls.track_seen_changed,
+                "description_changed": cls.description_changed,
+                "image_changed": cls.image_changed,
+                "track_message_changed": cls.track_message_changed,
+                "subscribers_changed": cls.subscribers_changed,
             },
         )
 
@@ -621,11 +621,11 @@ class _PlaylistCallbacks(object):
 
     @staticmethod
     @ffi.callback(
-        'void(sp_playlist *playlist, sp_track **tracks, int num_tracks, '
-        'int position, void *userdata)'
+        "void(sp_playlist *playlist, sp_track **tracks, int num_tracks, "
+        "int position, void *userdata)"
     )
     def tracks_added(sp_playlist, sp_tracks, num_tracks, index, userdata):
-        logger.debug('Tracks added to playlist')
+        logger.debug("Tracks added to playlist")
         playlist = Playlist._cached(
             spotify._session_instance, sp_playlist, add_ref=True
         )
@@ -639,10 +639,10 @@ class _PlaylistCallbacks(object):
 
     @staticmethod
     @ffi.callback(
-        'void(sp_playlist *playlist, int *tracks, int num_tracks, ' 'void *userdata)'
+        "void(sp_playlist *playlist, int *tracks, int num_tracks, " "void *userdata)"
     )
     def tracks_removed(sp_playlist, tracks, num_tracks, userdata):
-        logger.debug('Tracks removed from playlist')
+        logger.debug("Tracks removed from playlist")
         playlist = Playlist._cached(
             spotify._session_instance, sp_playlist, add_ref=True
         )
@@ -651,11 +651,11 @@ class _PlaylistCallbacks(object):
 
     @staticmethod
     @ffi.callback(
-        'void(sp_playlist *playlist, int *tracks, int num_tracks, '
-        'int position, void *userdata)'
+        "void(sp_playlist *playlist, int *tracks, int num_tracks, "
+        "int position, void *userdata)"
     )
     def tracks_moved(sp_playlist, old_indexes, num_tracks, new_index, userdata):
-        logger.debug('Tracks moved within playlist')
+        logger.debug("Tracks moved within playlist")
         playlist = Playlist._cached(
             spotify._session_instance, sp_playlist, add_ref=True
         )
@@ -663,36 +663,36 @@ class _PlaylistCallbacks(object):
         playlist.emit(PlaylistEvent.TRACKS_MOVED, playlist, old_indexes, int(new_index))
 
     @staticmethod
-    @ffi.callback('void(sp_playlist *playlist, void *userdata)')
+    @ffi.callback("void(sp_playlist *playlist, void *userdata)")
     def playlist_renamed(sp_playlist, userdata):
-        logger.debug('Playlist renamed')
+        logger.debug("Playlist renamed")
         playlist = Playlist._cached(
             spotify._session_instance, sp_playlist, add_ref=True
         )
         playlist.emit(PlaylistEvent.PLAYLIST_RENAMED, playlist)
 
     @staticmethod
-    @ffi.callback('void(sp_playlist *playlist, void *userdata)')
+    @ffi.callback("void(sp_playlist *playlist, void *userdata)")
     def playlist_state_changed(sp_playlist, userdata):
-        logger.debug('Playlist state changed')
+        logger.debug("Playlist state changed")
         playlist = Playlist._cached(
             spotify._session_instance, sp_playlist, add_ref=True
         )
         playlist.emit(PlaylistEvent.PLAYLIST_STATE_CHANGED, playlist)
 
     @staticmethod
-    @ffi.callback('void(sp_playlist *playlist, bool done, void *userdata)')
+    @ffi.callback("void(sp_playlist *playlist, bool done, void *userdata)")
     def playlist_update_in_progress(sp_playlist, done, userdata):
-        logger.debug('Playlist update in progress')
+        logger.debug("Playlist update in progress")
         playlist = Playlist._cached(
             spotify._session_instance, sp_playlist, add_ref=True
         )
         playlist.emit(PlaylistEvent.PLAYLIST_UPDATE_IN_PROGRESS, playlist, bool(done))
 
     @staticmethod
-    @ffi.callback('void(sp_playlist *playlist, void *userdata)')
+    @ffi.callback("void(sp_playlist *playlist, void *userdata)")
     def playlist_metadata_updated(sp_playlist, userdata):
-        logger.debug('Playlist metadata updated')
+        logger.debug("Playlist metadata updated")
         playlist = Playlist._cached(
             spotify._session_instance, sp_playlist, add_ref=True
         )
@@ -700,11 +700,11 @@ class _PlaylistCallbacks(object):
 
     @staticmethod
     @ffi.callback(
-        'void(sp_playlist *playlist, int position, sp_user *user, '
-        'int when, void *userdata)'
+        "void(sp_playlist *playlist, int position, sp_user *user, "
+        "int when, void *userdata)"
     )
     def track_created_changed(sp_playlist, index, sp_user, when, userdata):
-        logger.debug('Playlist track created changed')
+        logger.debug("Playlist track created changed")
         playlist = Playlist._cached(
             spotify._session_instance, sp_playlist, add_ref=True
         )
@@ -719,10 +719,10 @@ class _PlaylistCallbacks(object):
 
     @staticmethod
     @ffi.callback(
-        'void(sp_playlist *playlist, int position, bool seen, void *userdata)'
+        "void(sp_playlist *playlist, int position, bool seen, void *userdata)"
     )
     def track_seen_changed(sp_playlist, index, seen, userdata):
-        logger.debug('Playlist track seen changed')
+        logger.debug("Playlist track seen changed")
         playlist = Playlist._cached(
             spotify._session_instance, sp_playlist, add_ref=True
         )
@@ -731,9 +731,9 @@ class _PlaylistCallbacks(object):
         )
 
     @staticmethod
-    @ffi.callback('void(sp_playlist *playlist, char *desc, void *userdata)')
+    @ffi.callback("void(sp_playlist *playlist, char *desc, void *userdata)")
     def description_changed(sp_playlist, desc, userdata):
-        logger.debug('Playlist description changed')
+        logger.debug("Playlist description changed")
         playlist = Playlist._cached(
             spotify._session_instance, sp_playlist, add_ref=True
         )
@@ -742,9 +742,9 @@ class _PlaylistCallbacks(object):
         )
 
     @staticmethod
-    @ffi.callback('void(sp_playlist *playlist, byte *image, void *userdata)')
+    @ffi.callback("void(sp_playlist *playlist, byte *image, void *userdata)")
     def image_changed(sp_playlist, image_id, userdata):
-        logger.debug('Playlist image changed')
+        logger.debug("Playlist image changed")
         playlist = Playlist._cached(
             spotify._session_instance, sp_playlist, add_ref=True
         )
@@ -756,10 +756,10 @@ class _PlaylistCallbacks(object):
 
     @staticmethod
     @ffi.callback(
-        'void(sp_playlist *playlist, int position, char *message, ' 'void *userdata)'
+        "void(sp_playlist *playlist, int position, char *message, " "void *userdata)"
     )
     def track_message_changed(sp_playlist, index, message, userdata):
-        logger.debug('Playlist track message changed')
+        logger.debug("Playlist track message changed")
         playlist = Playlist._cached(
             spotify._session_instance, sp_playlist, add_ref=True
         )
@@ -771,16 +771,16 @@ class _PlaylistCallbacks(object):
         )
 
     @staticmethod
-    @ffi.callback('void(sp_playlist *playlist, void *userdata)')
+    @ffi.callback("void(sp_playlist *playlist, void *userdata)")
     def subscribers_changed(sp_playlist, userdata):
-        logger.debug('Playlist subscribers changed')
+        logger.debug("Playlist subscribers changed")
         playlist = Playlist._cached(
             spotify._session_instance, sp_playlist, add_ref=True
         )
         playlist.emit(PlaylistEvent.SUBSCRIBERS_CHANGED, playlist)
 
 
-@utils.make_enum('SP_PLAYLIST_OFFLINE_STATUS_')
+@utils.make_enum("SP_PLAYLIST_OFFLINE_STATUS_")
 class PlaylistOfflineStatus(utils.IntEnum):
     pass
 
@@ -810,14 +810,14 @@ class _Tracks(utils.Sequence, compat.MutableSequence):
 
         if not isinstance(key, (int, slice)):
             raise TypeError(
-                'list indices must be int or slice, not %s' % key.__class__.__name__
+                "list indices must be int or slice, not %s" % key.__class__.__name__
             )
         if isinstance(key, slice):
             if not isinstance(value, compat.Iterable):
-                raise TypeError('can only assign an iterable')
+                raise TypeError("can only assign an iterable")
         if isinstance(key, int):
             if not 0 <= key < self.__len__():
-                raise IndexError('list index out of range')
+                raise IndexError("list index out of range")
             key = slice(key, key + 1)
             value = [value]
 
@@ -838,10 +838,10 @@ class _Tracks(utils.Sequence, compat.MutableSequence):
             return
         if not isinstance(key, int):
             raise TypeError(
-                'list indices must be int or slice, not %s' % key.__class__.__name__
+                "list indices must be int or slice, not %s" % key.__class__.__name__
             )
         if not 0 <= key < self.__len__():
-            raise IndexError('list index out of range')
+            raise IndexError("list index out of range")
         self._playlist.remove_tracks(key)
 
     def insert(self, index, value):

--- a/spotify/playlist.py
+++ b/spotify/playlist.py
@@ -53,9 +53,7 @@ class Playlist(utils.EventEmitter):
         if uri is not None:
             sp_playlist = spotify.Link(self._session, uri)._as_sp_playlist()
             if sp_playlist is None:
-                raise spotify.Error(
-                    'Failed to get playlist from Spotify URI: %r' % uri
-                )
+                raise spotify.Error('Failed to get playlist from Spotify URI: %r' % uri)
             session._cache[sp_playlist] = self
             add_ref = False
 
@@ -261,9 +259,7 @@ class Playlist(utils.EventEmitter):
             indexes = [indexes]
         indexes = list(set(indexes))  # Remove duplicates
         spotify.Error.maybe_raise(
-            lib.sp_playlist_remove_tracks(
-                self._sp_playlist, indexes, len(indexes)
-            )
+            lib.sp_playlist_remove_tracks(self._sp_playlist, indexes, len(indexes))
         )
 
     def reorder_tracks(self, indexes, new_index):
@@ -347,9 +343,7 @@ class Playlist(utils.EventEmitter):
         playlist loaded into RAM.
         """
         return bool(
-            lib.sp_playlist_is_in_ram(
-                self._session._sp_session, self._sp_playlist
-            )
+            lib.sp_playlist_is_in_ram(self._session._sp_session, self._sp_playlist)
         )
 
     def set_in_ram(self, in_ram=True):
@@ -645,8 +639,7 @@ class _PlaylistCallbacks(object):
 
     @staticmethod
     @ffi.callback(
-        'void(sp_playlist *playlist, int *tracks, int num_tracks, '
-        'void *userdata)'
+        'void(sp_playlist *playlist, int *tracks, int num_tracks, ' 'void *userdata)'
     )
     def tracks_removed(sp_playlist, tracks, num_tracks, userdata):
         logger.debug('Tracks removed from playlist')
@@ -667,9 +660,7 @@ class _PlaylistCallbacks(object):
             spotify._session_instance, sp_playlist, add_ref=True
         )
         old_indexes = [int(old_indexes[i]) for i in range(num_tracks)]
-        playlist.emit(
-            PlaylistEvent.TRACKS_MOVED, playlist, old_indexes, int(new_index)
-        )
+        playlist.emit(PlaylistEvent.TRACKS_MOVED, playlist, old_indexes, int(new_index))
 
     @staticmethod
     @ffi.callback('void(sp_playlist *playlist, void *userdata)')
@@ -696,9 +687,7 @@ class _PlaylistCallbacks(object):
         playlist = Playlist._cached(
             spotify._session_instance, sp_playlist, add_ref=True
         )
-        playlist.emit(
-            PlaylistEvent.PLAYLIST_UPDATE_IN_PROGRESS, playlist, bool(done)
-        )
+        playlist.emit(PlaylistEvent.PLAYLIST_UPDATE_IN_PROGRESS, playlist, bool(done))
 
     @staticmethod
     @ffi.callback('void(sp_playlist *playlist, void *userdata)')
@@ -719,9 +708,7 @@ class _PlaylistCallbacks(object):
         playlist = Playlist._cached(
             spotify._session_instance, sp_playlist, add_ref=True
         )
-        user = spotify.User(
-            spotify._session_instance, sp_user=sp_user, add_ref=True
-        )
+        user = spotify.User(spotify._session_instance, sp_user=sp_user, add_ref=True)
         playlist.emit(
             PlaylistEvent.TRACK_CREATED_CHANGED,
             playlist,
@@ -761,9 +748,7 @@ class _PlaylistCallbacks(object):
         playlist = Playlist._cached(
             spotify._session_instance, sp_playlist, add_ref=True
         )
-        sp_image = lib.sp_image_create(
-            spotify._session_instance._sp_session, image_id
-        )
+        sp_image = lib.sp_image_create(spotify._session_instance._sp_session, image_id)
         image = spotify.Image(
             spotify._session_instance, sp_image=sp_image, add_ref=False
         )
@@ -771,8 +756,7 @@ class _PlaylistCallbacks(object):
 
     @staticmethod
     @ffi.callback(
-        'void(sp_playlist *playlist, int position, char *message, '
-        'void *userdata)'
+        'void(sp_playlist *playlist, int position, char *message, ' 'void *userdata)'
     )
     def track_message_changed(sp_playlist, index, message, userdata):
         logger.debug('Playlist track message changed')
@@ -826,8 +810,7 @@ class _Tracks(utils.Sequence, compat.MutableSequence):
 
         if not isinstance(key, (int, slice)):
             raise TypeError(
-                'list indices must be int or slice, not %s'
-                % key.__class__.__name__
+                'list indices must be int or slice, not %s' % key.__class__.__name__
             )
         if isinstance(key, slice):
             if not isinstance(value, compat.Iterable):
@@ -855,8 +838,7 @@ class _Tracks(utils.Sequence, compat.MutableSequence):
             return
         if not isinstance(key, int):
             raise TypeError(
-                'list indices must be int or slice, not %s'
-                % key.__class__.__name__
+                'list indices must be int or slice, not %s' % key.__class__.__name__
             )
         if not 0 <= key < self.__len__():
             raise IndexError('list index out of range')

--- a/spotify/playlist_container.py
+++ b/spotify/playlist_container.py
@@ -9,11 +9,11 @@ import spotify
 from spotify import compat, ffi, lib, serialized, utils
 
 __all__ = [
-    'PlaylistContainer',
-    'PlaylistContainerEvent',
-    'PlaylistFolder',
-    'PlaylistPlaceholder',
-    'PlaylistType',
+    "PlaylistContainer",
+    "PlaylistContainerEvent",
+    "PlaylistFolder",
+    "PlaylistPlaceholder",
+    "PlaylistType",
 ]
 
 logger = logging.getLogger(__name__)
@@ -108,9 +108,9 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
         self._lib = lib
 
     def __del__(self):
-        if not hasattr(self, '_lib'):
+        if not hasattr(self, "_lib"):
             return
-        if getattr(self, '_sp_playlistcontainer_callbacks', None) is None:
+        if getattr(self, "_sp_playlistcontainer_callbacks", None) is None:
             return
         self._lib.sp_playlistcontainer_remove_callbacks(
             self._sp_playlistcontainer,
@@ -119,7 +119,7 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
         )
 
     def __repr__(self):
-        return 'PlaylistContainer(%s)' % pprint.pformat(list(self))
+        return "PlaylistContainer(%s)" % pprint.pformat(list(self))
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -164,12 +164,12 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
             return list(self).__getitem__(key)
         if not isinstance(key, int):
             raise TypeError(
-                'list indices must be int or slice, not %s' % key.__class__.__name__
+                "list indices must be int or slice, not %s" % key.__class__.__name__
             )
         if key < 0:
             key += self.__len__()
         if not 0 <= key < self.__len__():
-            raise IndexError('list index out of range')
+            raise IndexError("list index out of range")
 
         playlist_type = PlaylistType(
             lib.sp_playlistcontainer_playlist_type(self._sp_playlistcontainer, key)
@@ -199,21 +199,21 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
         elif playlist_type is PlaylistType.PLACEHOLDER:
             return PlaylistPlaceholder()
         else:
-            raise spotify.Error('Unknown playlist type: %r' % playlist_type)
+            raise spotify.Error("Unknown playlist type: %r" % playlist_type)
 
     def __setitem__(self, key, value):
         # Required by collections.abc.MutableSequence
 
         if not isinstance(key, (int, slice)):
             raise TypeError(
-                'list indices must be int or slice, not %s' % key.__class__.__name__
+                "list indices must be int or slice, not %s" % key.__class__.__name__
             )
         if isinstance(key, slice):
             if not isinstance(value, compat.Iterable):
-                raise TypeError('can only assign an iterable')
+                raise TypeError("can only assign an iterable")
         if isinstance(key, int):
             if not 0 <= key < self.__len__():
-                raise IndexError('list index out of range')
+                raise IndexError("list index out of range")
             key = slice(key, key + 1)
             value = [value]
 
@@ -240,10 +240,10 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
             return
         if not isinstance(key, int):
             raise TypeError(
-                'list indices must be int or slice, not %s' % key.__class__.__name__
+                "list indices must be int or slice, not %s" % key.__class__.__name__
             )
         if not 0 <= key < self.__len__():
-            raise IndexError('list index out of range')
+            raise IndexError("list index out of range")
         self.remove_playlist(key)
 
     @serialized
@@ -262,7 +262,7 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
             self._sp_playlistcontainer, utils.to_char(name)
         )
         if sp_playlist == ffi.NULL:
-            raise spotify.Error('Playlist creation failed')
+            raise spotify.Error("Playlist creation failed")
         playlist = spotify.Playlist._cached(self._session, sp_playlist, add_ref=True)
         if index is not None:
             self.move_playlist(self.__len__() - 1, index)
@@ -289,7 +289,7 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
             link = playlist.link
         else:
             raise TypeError(
-                'Argument must be Link or Playlist, got %s' % type(playlist)
+                "Argument must be Link or Playlist, got %s" % type(playlist)
             )
         sp_playlist = lib.sp_playlistcontainer_add_playlist(
             self._sp_playlistcontainer, link._sp_link
@@ -321,9 +321,9 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
 
     def _validate_name(self, name):
         if len(name) > 255:
-            raise ValueError('Playlist name cannot be longer than 255 chars')
-        if len(re.sub(r'\s+', '', name)) == 0:
-            raise ValueError('Playlist name cannot be space-only')
+            raise ValueError("Playlist name cannot be longer than 255 chars")
+        if len(re.sub(r"\s+", "", name)) == 0:
+            raise ValueError("Playlist name cannot be space-only")
 
     def remove_playlist(self, index, recursive=False):
         """Remove playlist at the given index from the container.
@@ -357,7 +357,7 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
                 indexes.append(i)
         assert (
             len(indexes) <= 2
-        ), 'Found more than 2 items with the same playlist folder ID'
+        ), "Found more than 2 items with the same playlist folder ID"
         if recursive and len(indexes) == 2:
             start, end = indexes
             indexes = list(range(start, end + 1))
@@ -405,7 +405,7 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
             self._sp_playlistcontainer, playlist._sp_playlist
         )
         if result == -1:
-            raise spotify.Error('Failed clearing unseen tracks')
+            raise spotify.Error("Failed clearing unseen tracks")
 
     def insert(self, index, value):
         # Required by collections.abc.MutableSequence
@@ -465,7 +465,7 @@ class PlaylistContainerEvent(object):
     functions just to log that they're called.
     """
 
-    PLAYLIST_ADDED = 'playlist_added'
+    PLAYLIST_ADDED = "playlist_added"
     """Called when a playlist is added to the container.
 
     :param playlist_container: the playlist container
@@ -476,7 +476,7 @@ class PlaylistContainerEvent(object):
     :type index: int
     """
 
-    PLAYLIST_REMOVED = 'playlist_removed'
+    PLAYLIST_REMOVED = "playlist_removed"
     """Called when a playlist is removed from the container.
 
     :param playlist_container: the playlist container
@@ -487,7 +487,7 @@ class PlaylistContainerEvent(object):
     :type index: int
     """
 
-    PLAYLIST_MOVED = 'playlist_moved'
+    PLAYLIST_MOVED = "playlist_moved"
     """Called when a playlist is moved in the container.
 
     :param playlist_container: the playlist container
@@ -500,7 +500,7 @@ class PlaylistContainerEvent(object):
     :type new_index: int
     """
 
-    CONTAINER_LOADED = 'container_loaded'
+    CONTAINER_LOADED = "container_loaded"
     """Called when the playlist container is loaded.
 
     :param playlist_container: the playlist container
@@ -515,12 +515,12 @@ class _PlaylistContainerCallbacks(object):
     @classmethod
     def get_struct(cls):
         return ffi.new(
-            'sp_playlistcontainer_callbacks *',
+            "sp_playlistcontainer_callbacks *",
             {
-                'playlist_added': cls.playlist_added,
-                'playlist_removed': cls.playlist_removed,
-                'playlist_moved': cls.playlist_moved,
-                'container_loaded': cls.container_loaded,
+                "playlist_added": cls.playlist_added,
+                "playlist_removed": cls.playlist_removed,
+                "playlist_moved": cls.playlist_moved,
+                "container_loaded": cls.container_loaded,
             },
         )
 
@@ -529,11 +529,11 @@ class _PlaylistContainerCallbacks(object):
 
     @staticmethod
     @ffi.callback(
-        'void(sp_playlistcontainer *pc, sp_playlist *playlist, int position, '
-        'void *userdata)'
+        "void(sp_playlistcontainer *pc, sp_playlist *playlist, int position, "
+        "void *userdata)"
     )
     def playlist_added(sp_playlistcontainer, sp_playlist, index, userdata):
-        logger.debug('Playlist added at index %d', index)
+        logger.debug("Playlist added at index %d", index)
         playlist_container = PlaylistContainer._cached(
             spotify._session_instance, sp_playlistcontainer, add_ref=True
         )
@@ -549,11 +549,11 @@ class _PlaylistContainerCallbacks(object):
 
     @staticmethod
     @ffi.callback(
-        'void(sp_playlistcontainer *pc, sp_playlist *playlist, int position, '
-        'void *userdata)'
+        "void(sp_playlistcontainer *pc, sp_playlist *playlist, int position, "
+        "void *userdata)"
     )
     def playlist_removed(sp_playlistcontainer, sp_playlist, index, userdata):
-        logger.debug('Playlist removed at index %d', index)
+        logger.debug("Playlist removed at index %d", index)
         playlist_container = PlaylistContainer._cached(
             spotify._session_instance, sp_playlistcontainer, add_ref=True
         )
@@ -569,13 +569,13 @@ class _PlaylistContainerCallbacks(object):
 
     @staticmethod
     @ffi.callback(
-        'void(sp_playlistcontainer *pc, sp_playlist *playlist, int position, '
-        'int new_position, void *userdata)'
+        "void(sp_playlistcontainer *pc, sp_playlist *playlist, int position, "
+        "int new_position, void *userdata)"
     )
     def playlist_moved(
         sp_playlistcontainer, sp_playlist, old_index, new_index, userdata
     ):
-        logger.debug('Playlist moved from index %d to %d', old_index, new_index)
+        logger.debug("Playlist moved from index %d to %d", old_index, new_index)
         playlist_container = PlaylistContainer._cached(
             spotify._session_instance, sp_playlistcontainer, add_ref=True
         )
@@ -591,9 +591,9 @@ class _PlaylistContainerCallbacks(object):
         )
 
     @staticmethod
-    @ffi.callback('void(sp_playlistcontainer *pc, void *userdata)')
+    @ffi.callback("void(sp_playlistcontainer *pc, void *userdata)")
     def container_loaded(sp_playlistcontainer, userdata):
-        logger.debug('Playlist container loaded')
+        logger.debug("Playlist container loaded")
         playlist_container = PlaylistContainer._cached(
             spotify._session_instance, sp_playlistcontainer, add_ref=True
         )
@@ -602,7 +602,7 @@ class _PlaylistContainerCallbacks(object):
         )
 
 
-class PlaylistFolder(collections.namedtuple('PlaylistFolder', ['id', 'name', 'type'])):
+class PlaylistFolder(collections.namedtuple("PlaylistFolder", ["id", "name", "type"])):
 
     """An object marking the start or end of a playlist folder."""
 
@@ -615,6 +615,6 @@ class PlaylistPlaceholder(object):
     pass
 
 
-@utils.make_enum('SP_PLAYLIST_TYPE_')
+@utils.make_enum("SP_PLAYLIST_TYPE_")
 class PlaylistType(utils.IntEnum):
     pass

--- a/spotify/playlist_container.py
+++ b/spotify/playlist_container.py
@@ -8,7 +8,6 @@ import re
 import spotify
 from spotify import compat, ffi, lib, serialized, utils
 
-
 __all__ = [
     'PlaylistContainer',
     'PlaylistContainerEvent',

--- a/spotify/playlist_container.py
+++ b/spotify/playlist_container.py
@@ -136,9 +136,7 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
     @property
     def is_loaded(self):
         """Whether the playlist container's data is loaded."""
-        return bool(
-            lib.sp_playlistcontainer_is_loaded(self._sp_playlistcontainer)
-        )
+        return bool(lib.sp_playlistcontainer_is_loaded(self._sp_playlistcontainer))
 
     def load(self, timeout=None):
         """Block until the playlist container's data is loaded.
@@ -153,9 +151,7 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
     def __len__(self):
         # Required by collections.abc.Sequence
 
-        length = lib.sp_playlistcontainer_num_playlists(
-            self._sp_playlistcontainer
-        )
+        length = lib.sp_playlistcontainer_num_playlists(self._sp_playlistcontainer)
         if length == -1:
             return 0
         return length
@@ -168,8 +164,7 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
             return list(self).__getitem__(key)
         if not isinstance(key, int):
             raise TypeError(
-                'list indices must be int or slice, not %s'
-                % key.__class__.__name__
+                'list indices must be int or slice, not %s' % key.__class__.__name__
             )
         if key < 0:
             key += self.__len__()
@@ -177,18 +172,14 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
             raise IndexError('list index out of range')
 
         playlist_type = PlaylistType(
-            lib.sp_playlistcontainer_playlist_type(
-                self._sp_playlistcontainer, key
-            )
+            lib.sp_playlistcontainer_playlist_type(self._sp_playlistcontainer, key)
         )
 
         if playlist_type is PlaylistType.PLAYLIST:
             sp_playlist = lib.sp_playlistcontainer_playlist(
                 self._sp_playlistcontainer, key
             )
-            return spotify.Playlist._cached(
-                self._session, sp_playlist, add_ref=True
-            )
+            return spotify.Playlist._cached(self._session, sp_playlist, add_ref=True)
         elif playlist_type in (
             PlaylistType.START_FOLDER,
             PlaylistType.END_FOLDER,
@@ -215,8 +206,7 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
 
         if not isinstance(key, (int, slice)):
             raise TypeError(
-                'list indices must be int or slice, not %s'
-                % key.__class__.__name__
+                'list indices must be int or slice, not %s' % key.__class__.__name__
             )
         if isinstance(key, slice):
             if not isinstance(value, compat.Iterable):
@@ -250,8 +240,7 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
             return
         if not isinstance(key, int):
             raise TypeError(
-                'list indices must be int or slice, not %s'
-                % key.__class__.__name__
+                'list indices must be int or slice, not %s' % key.__class__.__name__
             )
         if not 0 <= key < self.__len__():
             raise IndexError('list index out of range')
@@ -274,9 +263,7 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
         )
         if sp_playlist == ffi.NULL:
             raise spotify.Error('Playlist creation failed')
-        playlist = spotify.Playlist._cached(
-            self._session, sp_playlist, add_ref=True
-        )
+        playlist = spotify.Playlist._cached(self._session, sp_playlist, add_ref=True)
         if index is not None:
             self.move_playlist(self.__len__() - 1, index)
         return playlist
@@ -309,9 +296,7 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
         )
         if sp_playlist == ffi.NULL:
             return None
-        playlist = spotify.Playlist._cached(
-            self._session, sp_playlist, add_ref=True
-        )
+        playlist = spotify.Playlist._cached(self._session, sp_playlist, add_ref=True)
         if index is not None:
             self.move_playlist(self.__len__() - 1, index)
         return playlist
@@ -361,9 +346,7 @@ class PlaylistContainer(compat.MutableSequence, utils.EventEmitter):
             indexes = [index]
         for i in reversed(sorted(indexes)):
             spotify.Error.maybe_raise(
-                lib.sp_playlistcontainer_remove_playlist(
-                    self._sp_playlistcontainer, i
-                )
+                lib.sp_playlistcontainer_remove_playlist(self._sp_playlistcontainer, i)
             )
 
     @staticmethod
@@ -619,9 +602,7 @@ class _PlaylistContainerCallbacks(object):
         )
 
 
-class PlaylistFolder(
-    collections.namedtuple('PlaylistFolder', ['id', 'name', 'type'])
-):
+class PlaylistFolder(collections.namedtuple('PlaylistFolder', ['id', 'name', 'type'])):
 
     """An object marking the start or end of a playlist folder."""
 

--- a/spotify/playlist_track.py
+++ b/spotify/playlist_track.py
@@ -36,8 +36,7 @@ class PlaylistTrack(object):
     def __eq__(self, other):
         if isinstance(other, self.__class__):
             return (
-                self._sp_playlist == other._sp_playlist
-                and self._index == other._index
+                self._sp_playlist == other._sp_playlist and self._index == other._index
             )
         else:
             return False
@@ -71,9 +70,7 @@ class PlaylistTrack(object):
         """The :class:`~spotify.User` that added the track to the playlist."""
         return spotify.User(
             self._session,
-            sp_user=lib.sp_playlist_track_creator(
-                self._sp_playlist, self._index
-            ),
+            sp_user=lib.sp_playlist_track_creator(self._sp_playlist, self._index),
             add_ref=True,
         )
 
@@ -82,9 +79,7 @@ class PlaylistTrack(object):
 
     def set_seen(self, value):
         spotify.Error.maybe_raise(
-            lib.sp_playlist_track_set_seen(
-                self._sp_playlist, self._index, int(value)
-            )
+            lib.sp_playlist_track_set_seen(self._sp_playlist, self._index, int(value))
         )
 
     seen = property(is_seen, set_seen)

--- a/spotify/playlist_track.py
+++ b/spotify/playlist_track.py
@@ -5,7 +5,6 @@ import logging
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-
 __all__ = ['PlaylistTrack']
 
 logger = logging.getLogger(__name__)

--- a/spotify/playlist_track.py
+++ b/spotify/playlist_track.py
@@ -5,7 +5,7 @@ import logging
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-__all__ = ['PlaylistTrack']
+__all__ = ["PlaylistTrack"]
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ class PlaylistTrack(object):
         self._index = index
 
     def __repr__(self):
-        return 'PlaylistTrack(uri=%r, creator=%r, create_time=%d)' % (
+        return "PlaylistTrack(uri=%r, creator=%r, create_time=%d)" % (
             self.track.link.uri,
             self.creator,
             self.create_time,

--- a/spotify/playlist_unseen_tracks.py
+++ b/spotify/playlist_unseen_tracks.py
@@ -6,7 +6,6 @@ import pprint
 import spotify
 from spotify import compat, ffi, lib, serialized
 
-
 __all__ = ['PlaylistUnseenTracks']
 
 logger = logging.getLogger(__name__)

--- a/spotify/playlist_unseen_tracks.py
+++ b/spotify/playlist_unseen_tracks.py
@@ -6,7 +6,7 @@ import pprint
 import spotify
 from spotify import compat, ffi, lib, serialized
 
-__all__ = ['PlaylistUnseenTracks']
+__all__ = ["PlaylistUnseenTracks"]
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ class PlaylistUnseenTracks(compat.Sequence):
         self._sp_tracks_len = min(
             self._num_tracks, self._sp_tracks_len + self._BATCH_SIZE
         )
-        self._sp_tracks = ffi.new('sp_track *[]', self._sp_tracks_len)
+        self._sp_tracks = ffi.new("sp_track *[]", self._sp_tracks_len)
         self._num_tracks = lib.sp_playlistcontainer_get_unseen_tracks(
             self._sp_playlistcontainer,
             self._sp_playlist,
@@ -52,7 +52,7 @@ class PlaylistUnseenTracks(compat.Sequence):
         )
 
         if self._num_tracks < 0:
-            raise spotify.Error('Failed to get unseen tracks for playlist')
+            raise spotify.Error("Failed to get unseen tracks for playlist")
 
     def __len__(self):
         return self._num_tracks
@@ -62,12 +62,12 @@ class PlaylistUnseenTracks(compat.Sequence):
             return list(self).__getitem__(key)
         if not isinstance(key, int):
             raise TypeError(
-                'list indices must be int or slice, not %s' % key.__class__.__name__
+                "list indices must be int or slice, not %s" % key.__class__.__name__
             )
         if key < 0:
             key += self.__len__()
         if not 0 <= key < self.__len__():
-            raise IndexError('list index out of range')
+            raise IndexError("list index out of range")
         while key >= self._sp_tracks_len:
             self._get_more_tracks()
         sp_track = self._sp_tracks[key]
@@ -76,4 +76,4 @@ class PlaylistUnseenTracks(compat.Sequence):
         return spotify.Track(self._session, sp_track=sp_track, add_ref=True)
 
     def __repr__(self):
-        return 'PlaylistUnseenTracks(%s)' % pprint.pformat(list(self))
+        return "PlaylistUnseenTracks(%s)" % pprint.pformat(list(self))

--- a/spotify/playlist_unseen_tracks.py
+++ b/spotify/playlist_unseen_tracks.py
@@ -62,8 +62,7 @@ class PlaylistUnseenTracks(compat.Sequence):
             return list(self).__getitem__(key)
         if not isinstance(key, int):
             raise TypeError(
-                'list indices must be int or slice, not %s'
-                % key.__class__.__name__
+                'list indices must be int or slice, not %s' % key.__class__.__name__
             )
         if key < 0:
             key += self.__len__()

--- a/spotify/search.py
+++ b/spotify/search.py
@@ -6,7 +6,7 @@ import threading
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-__all__ = ['Search', 'SearchPlaylist', 'SearchType']
+__all__ = ["Search", "SearchPlaylist", "SearchType"]
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class Search(object):
     def __init__(
         self,
         session,
-        query='',
+        query="",
         callback=None,
         track_offset=0,
         track_count=20,
@@ -37,7 +37,7 @@ class Search(object):
         add_ref=True,
     ):
 
-        assert query or sp_search, 'query or sp_search is required'
+        assert query or sp_search, "query or sp_search is required"
 
         self._session = session
         self.callback = callback
@@ -81,7 +81,7 @@ class Search(object):
         self._sp_search = ffi.gc(sp_search, lib.sp_search_release)
 
     def __repr__(self):
-        return 'Search(%r)' % self.link.uri
+        return "Search(%r)" % self.link.uri
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -352,12 +352,12 @@ class Search(object):
         )
 
 
-@ffi.callback('void(sp_search *, void *)')
+@ffi.callback("void(sp_search *, void *)")
 @serialized
 def _search_complete_callback(sp_search, handle):
-    logger.debug('search_complete_callback called')
+    logger.debug("search_complete_callback called")
     if handle == ffi.NULL:
-        logger.warning('pyspotify search_complete_callback called without userdata')
+        logger.warning("pyspotify search_complete_callback called without userdata")
         return
     (session, search_result, callback) = ffi.from_handle(handle)
     session._callback_handles.remove(handle)
@@ -386,7 +386,7 @@ class SearchPlaylist(object):
         self.image_uri = image_uri
 
     def __repr__(self):
-        return 'SearchPlaylist(name=%r, uri=%r)' % (self.name, self.uri)
+        return "SearchPlaylist(name=%r, uri=%r)" % (self.name, self.uri)
 
     @property
     def playlist(self):
@@ -401,6 +401,6 @@ class SearchPlaylist(object):
         return self._session.get_image(self.image_uri)
 
 
-@utils.make_enum('SP_SEARCH_')
+@utils.make_enum("SP_SEARCH_")
 class SearchType(utils.IntEnum):
     pass

--- a/spotify/search.py
+++ b/spotify/search.py
@@ -6,7 +6,6 @@ import threading
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-
 __all__ = ['Search', 'SearchPlaylist', 'SearchType']
 
 logger = logging.getLogger(__name__)

--- a/spotify/search.py
+++ b/spotify/search.py
@@ -141,9 +141,7 @@ class Search(object):
         Will always return :class:`None` if the search isn't loaded.
         """
         spotify.Error.maybe_raise(self.error)
-        did_you_mean = utils.to_unicode(
-            lib.sp_search_did_you_mean(self._sp_search)
-        )
+        did_you_mean = utils.to_unicode(lib.sp_search_did_you_mean(self._sp_search))
         return did_you_mean if did_you_mean else None
 
     @property
@@ -153,9 +151,7 @@ class Search(object):
 
         Will always return an empty list if the search isn't loaded.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return []
 
@@ -193,9 +189,7 @@ class Search(object):
 
         Will always return an empty list if the search isn't loaded.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return []
 
@@ -233,9 +227,7 @@ class Search(object):
 
         Will always return an empty list if the search isn't loaded.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return []
 
@@ -275,9 +267,7 @@ class Search(object):
 
         Will always return an empty list if the search isn't loaded.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return []
 
@@ -288,9 +278,7 @@ class Search(object):
                 name=utils.to_unicode(
                     lib.sp_search_playlist_name(self._sp_search, key)
                 ),
-                uri=utils.to_unicode(
-                    lib.sp_search_playlist_uri(self._sp_search, key)
-                ),
+                uri=utils.to_unicode(lib.sp_search_playlist_uri(self._sp_search, key)),
                 image_uri=utils.to_unicode(
                     lib.sp_search_playlist_image_uri(self._sp_search, key)
                 ),
@@ -369,9 +357,7 @@ class Search(object):
 def _search_complete_callback(sp_search, handle):
     logger.debug('search_complete_callback called')
     if handle == ffi.NULL:
-        logger.warning(
-            'pyspotify search_complete_callback called without userdata'
-        )
+        logger.warning('pyspotify search_complete_callback called without userdata')
         return
     (session, search_result, callback) = ffi.from_handle(handle)
     session._callback_handles.remove(handle)

--- a/spotify/session.py
+++ b/spotify/session.py
@@ -54,9 +54,7 @@ class Session(utils.EventEmitter):
         sp_session_ptr = ffi.new('sp_session **')
 
         spotify.Error.maybe_raise(
-            lib.sp_session_create(
-                self.config._sp_session_config, sp_session_ptr
-            )
+            lib.sp_session_create(self.config._sp_session_config, sp_session_ptr)
         )
 
         self._sp_session = ffi.gc(sp_session_ptr[0], lib.sp_session_release)
@@ -239,9 +237,7 @@ class Session(utils.EventEmitter):
             "and never restored it. "
             "Please use the Spotify Web API to work with playlists."
         )
-        sp_playlistcontainer = lib.sp_session_playlistcontainer(
-            self._sp_session
-        )
+        sp_playlistcontainer = lib.sp_session_playlistcontainer(self._sp_session)
         if sp_playlistcontainer == ffi.NULL:
             return None
         return spotify.PlaylistContainer._cached(
@@ -267,18 +263,14 @@ class Session(utils.EventEmitter):
         sp_playlist = lib.sp_session_inbox_create(self._sp_session)
         if sp_playlist == ffi.NULL:
             return None
-        return spotify.Playlist._cached(
-            self, sp_playlist=sp_playlist, add_ref=False
-        )
+        return spotify.Playlist._cached(self, sp_playlist=sp_playlist, add_ref=False)
 
     def set_cache_size(self, size):
         """Set maximum size in MB for libspotify's cache.
 
         If set to 0 (the default), up to 10% of the free disk space will be
         used."""
-        spotify.Error.maybe_raise(
-            lib.sp_session_set_cache_size(self._sp_session, size)
-        )
+        spotify.Error.maybe_raise(lib.sp_session_set_cache_size(self._sp_session, size))
 
     def flush_caches(self):
         """Write all cached data to disk.
@@ -342,9 +334,7 @@ class Session(utils.EventEmitter):
 
         return next_timeout[0]
 
-    def inbox_post_tracks(
-        self, canonical_username, tracks, message, callback=None
-    ):
+    def inbox_post_tracks(self, canonical_username, tracks, message, callback=None):
         """Post a ``message`` and one or more ``tracks`` to the inbox of the
         user with the given ``canonical_username``.
 
@@ -413,10 +403,8 @@ class Session(utils.EventEmitter):
             canonical_username = ffi.NULL
         else:
             canonical_username = utils.to_bytes(canonical_username)
-        sp_playlistcontainer = (
-            lib.sp_session_publishedcontainer_for_user_create(
-                self._sp_session, canonical_username
-            )
+        sp_playlistcontainer = lib.sp_session_publishedcontainer_for_user_create(
+            self._sp_session, canonical_username
         )
         if sp_playlistcontainer == ffi.NULL:
             return None
@@ -1077,22 +1065,15 @@ class _SessionCallbacks(object):
         )
 
     @staticmethod
-    @ffi.callback(
-        'int(sp_session *, const sp_audioformat *, const void *, int)'
-    )
+    @ffi.callback('int(sp_session *, const sp_audioformat *, const void *, int)')
     def music_delivery(sp_session, sp_audioformat, frames, num_frames):
         if not spotify._session_instance:
             return 0
-        if (
-            spotify._session_instance.num_listeners(SessionEvent.MUSIC_DELIVERY)
-            == 0
-        ):
+        if spotify._session_instance.num_listeners(SessionEvent.MUSIC_DELIVERY) == 0:
             logger.debug('Music delivery, but no listener')
             return 0
         audio_format = spotify.AudioFormat(sp_audioformat)
-        frames_buffer = ffi.buffer(
-            frames, audio_format.frame_size() * num_frames
-        )
+        frames_buffer = ffi.buffer(frames, audio_format.frame_size() * num_frames)
         frames_bytes = frames_buffer[:]
         num_frames_consumed = spotify._session_instance.call(
             SessionEvent.MUSIC_DELIVERY,
@@ -1186,9 +1167,7 @@ class _SessionCallbacks(object):
         if not spotify._session_instance:
             return
         if (
-            spotify._session_instance.num_listeners(
-                SessionEvent.GET_AUDIO_BUFFER_STATS
-            )
+            spotify._session_instance.num_listeners(SessionEvent.GET_AUDIO_BUFFER_STATS)
             == 0
         ):
             logger.debug('Audio buffer stats requested, but no listener')

--- a/spotify/session.py
+++ b/spotify/session.py
@@ -10,7 +10,7 @@ import spotify.player
 import spotify.social
 from spotify import ffi, lib, serialized, utils
 
-__all__ = ['Session', 'SessionEvent']
+__all__ = ["Session", "SessionEvent"]
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ class Session(utils.EventEmitter):
         super(Session, self).__init__()
 
         if spotify._session_instance is not None:
-            raise RuntimeError('Session has already been initialized')
+            raise RuntimeError("Session has already been initialized")
 
         if config is not None:
             self.config = config
@@ -51,7 +51,7 @@ class Session(utils.EventEmitter):
         if self.config.application_key is None:
             self.config.load_application_key_file()
 
-        sp_session_ptr = ffi.new('sp_session **')
+        sp_session_ptr = ffi.new("sp_session **")
 
         spotify.Error.maybe_raise(
             lib.sp_session_create(self.config._sp_session_config, sp_session_ptr)
@@ -155,7 +155,7 @@ class Session(utils.EventEmitter):
             password = ffi.NULL
             blob = utils.to_char(blob)
         else:
-            raise AttributeError('password or blob is required to login')
+            raise AttributeError("password or blob is required to login")
 
         spotify.Error.maybe_raise(
             lib.sp_session_login(
@@ -326,7 +326,7 @@ class Session(utils.EventEmitter):
         pyspotify provides an :class:`~spotify.EventLoop` that you can use for
         processing events when needed.
         """
-        next_timeout = ffi.new('int *')
+        next_timeout = ffi.new("int *")
 
         spotify.Error.maybe_raise(
             lib.sp_session_process_events(self._sp_session, next_timeout)
@@ -483,11 +483,11 @@ class Session(utils.EventEmitter):
         """
 
         if artist is None:
-            artist = ''
+            artist = ""
         if title is None:
-            title = ''
+            title = ""
         if album is None:
-            album = ''
+            album = ""
         if length is None:
             length = -1
 
@@ -639,8 +639,8 @@ class Session(utils.EventEmitter):
         Returns a :class:`Search` instance.
         """
         raise Exception(
-            'Spotify broke the libspotify search API 2016-02-03 '
-            'and never restored it.'
+            "Spotify broke the libspotify search API 2016-02-03 "
+            "and never restored it."
         )
 
     def get_toplist(
@@ -717,7 +717,7 @@ class SessionEvent(object):
     functions just to log that they're called.
     """
 
-    LOGGED_IN = 'logged_in'
+    LOGGED_IN = "logged_in"
     """Called when login has completed.
 
     Note that even if login has succeeded, that does not mean that you're
@@ -734,7 +734,7 @@ class SessionEvent(object):
     :type error_type: :class:`ErrorType`
     """
 
-    LOGGED_OUT = 'logged_out'
+    LOGGED_OUT = "logged_out"
     """Called when logout has completed or there is a permanent connection
     error.
 
@@ -742,7 +742,7 @@ class SessionEvent(object):
     :type session: :class:`Session`
     """
 
-    METADATA_UPDATED = 'metadata_updated'
+    METADATA_UPDATED = "metadata_updated"
     """Called when some metadata has been updated.
 
     There is no way to know what metadata was updated, so you'll have to
@@ -752,7 +752,7 @@ class SessionEvent(object):
     :type session: :class:`Session`
     """
 
-    CONNECTION_ERROR = 'connection_error'
+    CONNECTION_ERROR = "connection_error"
     """Called when there is a connection error and libspotify has problems
     reconnecting to the Spotify service.
 
@@ -765,7 +765,7 @@ class SessionEvent(object):
     :type error_type: :class:`ErrorType`
     """
 
-    MESSAGE_TO_USER = 'message_to_user'
+    MESSAGE_TO_USER = "message_to_user"
     """Called when libspotify wants to show a message to the end user.
 
     :param session: the current session
@@ -774,7 +774,7 @@ class SessionEvent(object):
     :type data: text
     """
 
-    NOTIFY_MAIN_THREAD = 'notify_main_thread'
+    NOTIFY_MAIN_THREAD = "notify_main_thread"
     """Called when processing on the main thread is needed.
 
     When this is called, you should call :meth:`~Session.process_events` from
@@ -791,7 +791,7 @@ class SessionEvent(object):
     :type session: :class:`Session`
     """
 
-    MUSIC_DELIVERY = 'music_delivery'
+    MUSIC_DELIVERY = "music_delivery"
     """Called when there is decompressed audio data available.
 
     If the function returns a lower number of frames consumed than
@@ -820,7 +820,7 @@ class SessionEvent(object):
     :returns: the number of frames consumed
     """
 
-    PLAY_TOKEN_LOST = 'play_token_lost'
+    PLAY_TOKEN_LOST = "play_token_lost"
     """Music has been paused because an account only allows music to be played
     from one location simultaneously.
 
@@ -830,7 +830,7 @@ class SessionEvent(object):
     :type session: :class:`Session`
     """
 
-    LOG_MESSAGE = 'log_message'
+    LOG_MESSAGE = "log_message"
     """Called when libspotify have something to log.
 
     Note that pyspotify logs this for you, so you'll probably never need to
@@ -842,14 +842,14 @@ class SessionEvent(object):
     :type data: text
     """
 
-    END_OF_TRACK = 'end_of_track'
+    END_OF_TRACK = "end_of_track"
     """Called when all audio data for the current track has been delivered.
 
     :param session: the current session
     :type session: :class:`Session`
     """
 
-    STREAMING_ERROR = 'streaming_error'
+    STREAMING_ERROR = "streaming_error"
     """Called when audio streaming cannot start or continue.
 
     :param session: the current session
@@ -858,14 +858,14 @@ class SessionEvent(object):
     :type error_type: :class:`ErrorType`
     """
 
-    USER_INFO_UPDATED = 'user_info_updated'
+    USER_INFO_UPDATED = "user_info_updated"
     """Called when anything related to :class:`User` objects is updated.
 
     :param session: the current session
     :type session: :class:`Session`
     """
 
-    START_PLAYBACK = 'start_playback'
+    START_PLAYBACK = "start_playback"
     """Called when audio playback should start.
 
     You need to implement a listener for the :attr:`GET_AUDIO_BUFFER_STATS`
@@ -881,7 +881,7 @@ class SessionEvent(object):
     :type session: :class:`Session`
     """
 
-    STOP_PLAYBACK = 'stop_playback'
+    STOP_PLAYBACK = "stop_playback"
     """Called when audio playback should stop.
 
     You need to implement a listener for the :attr:`GET_AUDIO_BUFFER_STATS`
@@ -897,7 +897,7 @@ class SessionEvent(object):
     :type session: :class:`Session`
     """
 
-    GET_AUDIO_BUFFER_STATS = 'get_audio_buffer_stats'
+    GET_AUDIO_BUFFER_STATS = "get_audio_buffer_stats"
     """Called to query the application about its audio buffer.
 
     .. note::
@@ -915,14 +915,14 @@ class SessionEvent(object):
     :returns: an :class:`AudioBufferStats` instance
     """
 
-    OFFLINE_STATUS_UPDATED = 'offline_status_updated'
+    OFFLINE_STATUS_UPDATED = "offline_status_updated"
     """Called when offline sync status is updated.
 
     :param session: the current session
     :type session: :class:`Session`
     """
 
-    CREDENTIALS_BLOB_UPDATED = 'credentials_blob_updated'
+    CREDENTIALS_BLOB_UPDATED = "credentials_blob_updated"
     """Called when storable credentials have been updated, typically right
     after login.
 
@@ -935,7 +935,7 @@ class SessionEvent(object):
     :type blob: bytestring
     """
 
-    CONNECTION_STATE_UPDATED = 'connection_state_updated'
+    CONNECTION_STATE_UPDATED = "connection_state_updated"
     """Called when the connection state is updated.
 
     The connection state includes login, logout, offline mode, etc.
@@ -944,7 +944,7 @@ class SessionEvent(object):
     :type session: :class:`Session`
     """
 
-    SCROBBLE_ERROR = 'scrobble_error'
+    SCROBBLE_ERROR = "scrobble_error"
     """Called when there is a scrobble error event.
 
     :param session: the current session
@@ -953,7 +953,7 @@ class SessionEvent(object):
     :type error_type: :class:`ErrorType`
     """
 
-    PRIVATE_SESSION_MODE_CHANGED = 'private_session_mode_changed'
+    PRIVATE_SESSION_MODE_CHANGED = "private_session_mode_changed"
     """Called when there is a change in the private session mode.
 
     :param session: the current session
@@ -970,28 +970,28 @@ class _SessionCallbacks(object):
     @classmethod
     def get_struct(cls):
         return ffi.new(
-            'sp_session_callbacks *',
+            "sp_session_callbacks *",
             {
-                'logged_in': cls.logged_in,
-                'logged_out': cls.logged_out,
-                'metadata_updated': cls.metadata_updated,
-                'connection_error': cls.connection_error,
-                'message_to_user': cls.message_to_user,
-                'notify_main_thread': cls.notify_main_thread,
-                'music_delivery': cls.music_delivery,
-                'play_token_lost': cls.play_token_lost,
-                'log_message': cls.log_message,
-                'end_of_track': cls.end_of_track,
-                'streaming_error': cls.streaming_error,
-                'userinfo_updated': cls.user_info_updated,
-                'start_playback': cls.start_playback,
-                'stop_playback': cls.stop_playback,
-                'get_audio_buffer_stats': cls.get_audio_buffer_stats,
-                'offline_status_updated': cls.offline_status_updated,
-                'credentials_blob_updated': cls.credentials_blob_updated,
-                'connectionstate_updated': cls.connection_state_updated,
-                'scrobble_error': cls.scrobble_error,
-                'private_session_mode_changed': cls.private_session_mode_changed,
+                "logged_in": cls.logged_in,
+                "logged_out": cls.logged_out,
+                "metadata_updated": cls.metadata_updated,
+                "connection_error": cls.connection_error,
+                "message_to_user": cls.message_to_user,
+                "notify_main_thread": cls.notify_main_thread,
+                "music_delivery": cls.music_delivery,
+                "play_token_lost": cls.play_token_lost,
+                "log_message": cls.log_message,
+                "end_of_track": cls.end_of_track,
+                "streaming_error": cls.streaming_error,
+                "userinfo_updated": cls.user_info_updated,
+                "start_playback": cls.start_playback,
+                "stop_playback": cls.stop_playback,
+                "get_audio_buffer_stats": cls.get_audio_buffer_stats,
+                "offline_status_updated": cls.offline_status_updated,
+                "credentials_blob_updated": cls.credentials_blob_updated,
+                "connectionstate_updated": cls.connection_state_updated,
+                "scrobble_error": cls.scrobble_error,
+                "private_session_mode_changed": cls.private_session_mode_changed,
             },
         )
 
@@ -999,78 +999,78 @@ class _SessionCallbacks(object):
     # callbacks.
 
     @staticmethod
-    @ffi.callback('void(sp_session *, sp_error)')
+    @ffi.callback("void(sp_session *, sp_error)")
     def logged_in(sp_session, sp_error):
         if not spotify._session_instance:
             return
         error_type = spotify.ErrorType(sp_error)
         if error_type == spotify.ErrorType.OK:
-            logger.info('Spotify logged in')
+            logger.info("Spotify logged in")
         else:
-            logger.error('Spotify login error: %r', error_type)
+            logger.error("Spotify login error: %r", error_type)
         spotify._session_instance.emit(
             SessionEvent.LOGGED_IN, spotify._session_instance, error_type
         )
 
     @staticmethod
-    @ffi.callback('void(sp_session *)')
+    @ffi.callback("void(sp_session *)")
     def logged_out(sp_session):
         if not spotify._session_instance:
             return
-        logger.info('Spotify logged out')
+        logger.info("Spotify logged out")
         spotify._session_instance.emit(
             SessionEvent.LOGGED_OUT, spotify._session_instance
         )
 
     @staticmethod
-    @ffi.callback('void(sp_session *)')
+    @ffi.callback("void(sp_session *)")
     def metadata_updated(sp_session):
         if not spotify._session_instance:
             return
-        logger.debug('Metadata updated')
+        logger.debug("Metadata updated")
         spotify._session_instance.emit(
             SessionEvent.METADATA_UPDATED, spotify._session_instance
         )
 
     @staticmethod
-    @ffi.callback('void(sp_session *, sp_error)')
+    @ffi.callback("void(sp_session *, sp_error)")
     def connection_error(sp_session, sp_error):
         if not spotify._session_instance:
             return
         error_type = spotify.ErrorType(sp_error)
-        logger.error('Spotify connection error: %r', error_type)
+        logger.error("Spotify connection error: %r", error_type)
         spotify._session_instance.emit(
             SessionEvent.CONNECTION_ERROR, spotify._session_instance, error_type
         )
 
     @staticmethod
-    @ffi.callback('void(sp_session *, const char *)')
+    @ffi.callback("void(sp_session *, const char *)")
     def message_to_user(sp_session, data):
         if not spotify._session_instance:
             return
         data = utils.to_unicode(data).strip()
-        logger.debug('Message to user: %s', data)
+        logger.debug("Message to user: %s", data)
         spotify._session_instance.emit(
             SessionEvent.MESSAGE_TO_USER, spotify._session_instance, data
         )
 
     @staticmethod
-    @ffi.callback('void(sp_session *)')
+    @ffi.callback("void(sp_session *)")
     def notify_main_thread(sp_session):
         if not spotify._session_instance:
             return
-        logger.debug('Notify main thread')
+        logger.debug("Notify main thread")
         spotify._session_instance.emit(
             SessionEvent.NOTIFY_MAIN_THREAD, spotify._session_instance
         )
 
     @staticmethod
-    @ffi.callback('int(sp_session *, const sp_audioformat *, const void *, int)')
+    @ffi.callback("int(sp_session *, const sp_audioformat *, const void *, int)")
     def music_delivery(sp_session, sp_audioformat, frames, num_frames):
         if not spotify._session_instance:
             return 0
         if spotify._session_instance.num_listeners(SessionEvent.MUSIC_DELIVERY) == 0:
-            logger.debug('Music delivery, but no listener')
+            logger.debug("Music delivery, but no listener")
             return 0
         audio_format = spotify.AudioFormat(sp_audioformat)
         frames_buffer = ffi.buffer(frames, audio_format.frame_size() * num_frames)
@@ -1083,86 +1083,86 @@ class _SessionCallbacks(object):
             num_frames,
         )
         logger.debug(
-            'Music delivery of %d frames, %d consumed',
+            "Music delivery of %d frames, %d consumed",
             num_frames,
             num_frames_consumed,
         )
         return num_frames_consumed
 
     @staticmethod
-    @ffi.callback('void(sp_session *)')
+    @ffi.callback("void(sp_session *)")
     def play_token_lost(sp_session):
         if not spotify._session_instance:
             return
-        logger.debug('Play token lost')
+        logger.debug("Play token lost")
         spotify._session_instance.emit(
             SessionEvent.PLAY_TOKEN_LOST, spotify._session_instance
         )
 
     @staticmethod
-    @ffi.callback('void(sp_session *, const char *)')
+    @ffi.callback("void(sp_session *, const char *)")
     def log_message(sp_session, data):
         if not spotify._session_instance:
             return
         data = utils.to_unicode(data).strip()
-        logger.debug('libspotify log message: %s', data)
+        logger.debug("libspotify log message: %s", data)
         spotify._session_instance.emit(
             SessionEvent.LOG_MESSAGE, spotify._session_instance, data
         )
 
     @staticmethod
-    @ffi.callback('void(sp_session *)')
+    @ffi.callback("void(sp_session *)")
     def end_of_track(sp_session):
         if not spotify._session_instance:
             return
-        logger.debug('End of track')
+        logger.debug("End of track")
         spotify._session_instance.emit(
             SessionEvent.END_OF_TRACK, spotify._session_instance
         )
 
     @staticmethod
-    @ffi.callback('void(sp_session *, sp_error)')
+    @ffi.callback("void(sp_session *, sp_error)")
     def streaming_error(sp_session, sp_error):
         if not spotify._session_instance:
             return
         error_type = spotify.ErrorType(sp_error)
-        logger.error('Spotify streaming error: %r', error_type)
+        logger.error("Spotify streaming error: %r", error_type)
         spotify._session_instance.emit(
             SessionEvent.STREAMING_ERROR, spotify._session_instance, error_type
         )
 
     @staticmethod
-    @ffi.callback('void(sp_session *)')
+    @ffi.callback("void(sp_session *)")
     def user_info_updated(sp_session):
         if not spotify._session_instance:
             return
-        logger.debug('User info updated')
+        logger.debug("User info updated")
         spotify._session_instance.emit(
             SessionEvent.USER_INFO_UPDATED, spotify._session_instance
         )
 
     @staticmethod
-    @ffi.callback('void(sp_session *)')
+    @ffi.callback("void(sp_session *)")
     def start_playback(sp_session):
         if not spotify._session_instance:
             return
-        logger.debug('Start playback called')
+        logger.debug("Start playback called")
         spotify._session_instance.emit(
             SessionEvent.START_PLAYBACK, spotify._session_instance
         )
 
     @staticmethod
-    @ffi.callback('void(sp_session *)')
+    @ffi.callback("void(sp_session *)")
     def stop_playback(sp_session):
         if not spotify._session_instance:
             return
-        logger.debug('Stop playback called')
+        logger.debug("Stop playback called")
         spotify._session_instance.emit(
             SessionEvent.STOP_PLAYBACK, spotify._session_instance
         )
 
     @staticmethod
-    @ffi.callback('void(sp_session *, sp_audio_buffer_stats *)')
+    @ffi.callback("void(sp_session *, sp_audio_buffer_stats *)")
     def get_audio_buffer_stats(sp_session, sp_audio_buffer_stats):
         if not spotify._session_instance:
             return
@@ -1170,9 +1170,9 @@ class _SessionCallbacks(object):
             spotify._session_instance.num_listeners(SessionEvent.GET_AUDIO_BUFFER_STATS)
             == 0
         ):
-            logger.debug('Audio buffer stats requested, but no listener')
+            logger.debug("Audio buffer stats requested, but no listener")
             return
-        logger.debug('Audio buffer stats requested')
+        logger.debug("Audio buffer stats requested")
         stats = spotify._session_instance.call(
             SessionEvent.GET_AUDIO_BUFFER_STATS, spotify._session_instance
         )
@@ -1180,22 +1180,22 @@ class _SessionCallbacks(object):
         sp_audio_buffer_stats.stutter = stats.stutter
 
     @staticmethod
-    @ffi.callback('void(sp_session *)')
+    @ffi.callback("void(sp_session *)")
     def offline_status_updated(sp_session):
         if not spotify._session_instance:
             return
-        logger.debug('Offline status updated')
+        logger.debug("Offline status updated")
         spotify._session_instance.emit(
             SessionEvent.OFFLINE_STATUS_UPDATED, spotify._session_instance
         )
 
     @staticmethod
-    @ffi.callback('void(sp_session *, const char *)')
+    @ffi.callback("void(sp_session *, const char *)")
     def credentials_blob_updated(sp_session, data):
         if not spotify._session_instance:
             return
         data = ffi.string(data)
-        logger.debug('Credentials blob updated: %r', data)
+        logger.debug("Credentials blob updated: %r", data)
         spotify._session_instance.emit(
             SessionEvent.CREDENTIALS_BLOB_UPDATED,
             spotify._session_instance,
@@ -1203,34 +1203,34 @@ class _SessionCallbacks(object):
         )
 
     @staticmethod
-    @ffi.callback('void(sp_session *)')
+    @ffi.callback("void(sp_session *)")
     def connection_state_updated(sp_session):
         if not spotify._session_instance:
             return
-        logger.debug('Connection state updated')
+        logger.debug("Connection state updated")
         spotify._session_instance.emit(
             SessionEvent.CONNECTION_STATE_UPDATED, spotify._session_instance
         )
 
     @staticmethod
-    @ffi.callback('void(sp_session *, sp_error)')
+    @ffi.callback("void(sp_session *, sp_error)")
     def scrobble_error(sp_session, sp_error):
         if not spotify._session_instance:
             return
         error_type = spotify.ErrorType(sp_error)
-        logger.error('Spotify scrobble error: %r', error_type)
+        logger.error("Spotify scrobble error: %r", error_type)
         spotify._session_instance.emit(
             SessionEvent.SCROBBLE_ERROR, spotify._session_instance, error_type
         )
 
     @staticmethod
-    @ffi.callback('void(sp_session *, bool)')
+    @ffi.callback("void(sp_session *, bool)")
     def private_session_mode_changed(sp_session, is_private):
         if not spotify._session_instance:
             return
         is_private = bool(is_private)
-        status = 'private' if is_private else 'public'
-        logger.debug('Private session mode changed: %s', status)
+        status = "private" if is_private else "public"
+        logger.debug("Private session mode changed: %s", status)
         spotify._session_instance.emit(
             SessionEvent.PRIVATE_SESSION_MODE_CHANGED,
             spotify._session_instance,

--- a/spotify/session.py
+++ b/spotify/session.py
@@ -10,7 +10,6 @@ import spotify.player
 import spotify.social
 from spotify import ffi, lib, serialized, utils
 
-
 __all__ = ['Session', 'SessionEvent']
 
 logger = logging.getLogger(__name__)

--- a/spotify/sink.py
+++ b/spotify/sink.py
@@ -15,26 +15,16 @@ class Sink(object):
         only need to call this method if you ever call :meth:`off` and want to
         turn the sink back on.
         """
-        assert (
-            self._session.num_listeners(spotify.SessionEvent.MUSIC_DELIVERY)
-            == 0
-        )
-        self._session.on(
-            spotify.SessionEvent.MUSIC_DELIVERY, self._on_music_delivery
-        )
+        assert self._session.num_listeners(spotify.SessionEvent.MUSIC_DELIVERY) == 0
+        self._session.on(spotify.SessionEvent.MUSIC_DELIVERY, self._on_music_delivery)
 
     def off(self):
         """Turn off the audio sink.
 
         This disconnects the sink from the relevant session events.
         """
-        self._session.off(
-            spotify.SessionEvent.MUSIC_DELIVERY, self._on_music_delivery
-        )
-        assert (
-            self._session.num_listeners(spotify.SessionEvent.MUSIC_DELIVERY)
-            == 0
-        )
+        self._session.off(spotify.SessionEvent.MUSIC_DELIVERY, self._on_music_delivery)
+        assert self._session.num_listeners(spotify.SessionEvent.MUSIC_DELIVERY) == 0
         self._close()
 
     def _on_music_delivery(self, session, audio_format, frames, num_frames):
@@ -94,9 +84,7 @@ class AlsaSink(Sink):
         self.on()
 
     def _on_music_delivery(self, session, audio_format, frames, num_frames):
-        assert (
-            audio_format.sample_type == spotify.SampleType.INT16_NATIVE_ENDIAN
-        )
+        assert audio_format.sample_type == spotify.SampleType.INT16_NATIVE_ENDIAN
 
         if self._device is None:
             if hasattr(self._alsaaudio, 'pcms'):  # pyalsaaudio >= 0.8
@@ -163,9 +151,7 @@ class PortAudioSink(Sink):
         self.on()
 
     def _on_music_delivery(self, session, audio_format, frames, num_frames):
-        assert (
-            audio_format.sample_type == spotify.SampleType.INT16_NATIVE_ENDIAN
-        )
+        assert audio_format.sample_type == spotify.SampleType.INT16_NATIVE_ENDIAN
 
         if self._stream is None:
             self._stream = self._device.open(

--- a/spotify/sink.py
+++ b/spotify/sink.py
@@ -4,7 +4,7 @@ import sys
 
 import spotify
 
-__all__ = ['AlsaSink', 'PortAudioSink']
+__all__ = ["AlsaSink", "PortAudioSink"]
 
 
 class Sink(object):
@@ -72,7 +72,7 @@ class AlsaSink(Sink):
         # Listen to music...
     """
 
-    def __init__(self, session, device='default'):
+    def __init__(self, session, device="default"):
         self._session = session
         self._device_name = device
 
@@ -87,7 +87,7 @@ class AlsaSink(Sink):
         assert audio_format.sample_type == spotify.SampleType.INT16_NATIVE_ENDIAN
 
         if self._device is None:
-            if hasattr(self._alsaaudio, 'pcms'):  # pyalsaaudio >= 0.8
+            if hasattr(self._alsaaudio, "pcms"):  # pyalsaaudio >= 0.8
                 self._device = self._alsaaudio.PCM(
                     mode=self._alsaaudio.PCM_NONBLOCK, device=self._device_name
                 )
@@ -95,7 +95,7 @@ class AlsaSink(Sink):
                 self._device = self._alsaaudio.PCM(
                     mode=self._alsaaudio.PCM_NONBLOCK, card=self._device_name
                 )
-            if sys.byteorder == 'little':
+            if sys.byteorder == "little":
                 self._device.setformat(self._alsaaudio.PCM_FORMAT_S16_LE)
             else:
                 self._device.setformat(self._alsaaudio.PCM_FORMAT_S16_BE)

--- a/spotify/social.py
+++ b/spotify/social.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import spotify
 from spotify import ffi, lib, utils
 
-__all__ = ['ScrobblingState', 'SocialProvider']
+__all__ = ["ScrobblingState", "SocialProvider"]
 
 
 class Social(object):
@@ -34,9 +34,9 @@ class Social(object):
         # has been reported to Spotify on IRC.
         if self._session.connection.state != spotify.ConnectionState.LOGGED_IN:
             raise RuntimeError(
-                'private_session can only be set when the session is logged '
-                'in. This is temporary workaround of a libspotify bug, '
-                'causing the application to segfault otherwise.'
+                "private_session can only be set when the session is logged "
+                "in. This is temporary workaround of a libspotify bug, "
+                "causing the application to segfault otherwise."
             )
         spotify.Error.maybe_raise(
             lib.sp_session_set_private_session(self._session._sp_session, bool(value))
@@ -45,7 +45,7 @@ class Social(object):
     def is_scrobbling(self, social_provider):
         """Get the :class:`ScrobblingState` for the given
         ``social_provider``."""
-        scrobbling_state = ffi.new('sp_scrobbling_state *')
+        scrobbling_state = ffi.new("sp_scrobbling_state *")
         spotify.Error.maybe_raise(
             lib.sp_session_is_scrobbling(
                 self._session._sp_session, social_provider, scrobbling_state
@@ -55,7 +55,7 @@ class Social(object):
 
     def is_scrobbling_possible(self, social_provider):
         """Check if the scrobbling settings should be shown to the user."""
-        out = ffi.new('bool *')
+        out = ffi.new("bool *")
         spotify.Error.maybe_raise(
             lib.sp_session_is_scrobbling_possible(
                 self._session._sp_session, social_provider, out
@@ -90,11 +90,11 @@ class Social(object):
         )
 
 
-@utils.make_enum('SP_SCROBBLING_STATE_')
+@utils.make_enum("SP_SCROBBLING_STATE_")
 class ScrobblingState(utils.IntEnum):
     pass
 
 
-@utils.make_enum('SP_SOCIAL_PROVIDER_')
+@utils.make_enum("SP_SOCIAL_PROVIDER_")
 class SocialProvider(utils.IntEnum):
     pass

--- a/spotify/social.py
+++ b/spotify/social.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import spotify
 from spotify import ffi, lib, utils
 
-
 __all__ = ['ScrobblingState', 'SocialProvider']
 
 

--- a/spotify/social.py
+++ b/spotify/social.py
@@ -24,9 +24,7 @@ class Social(object):
 
         Set to :class:`True` or :class:`False` to change.
         """
-        return bool(
-            lib.sp_session_is_private_session(self._session._sp_session)
-        )
+        return bool(lib.sp_session_is_private_session(self._session._sp_session))
 
     @private_session.setter
     def private_session(self, value):
@@ -41,9 +39,7 @@ class Social(object):
                 'causing the application to segfault otherwise.'
             )
         spotify.Error.maybe_raise(
-            lib.sp_session_set_private_session(
-                self._session._sp_session, bool(value)
-            )
+            lib.sp_session_set_private_session(self._session._sp_session, bool(value))
         )
 
     def is_scrobbling(self, social_provider):

--- a/spotify/toplist.py
+++ b/spotify/toplist.py
@@ -57,9 +57,7 @@ class Toplist(object):
 
         assert (
             type is not None and region is not None
-        ) or sp_toplistbrowse, (
-            'type and region, or sp_toplistbrowse, is required'
-        )
+        ) or sp_toplistbrowse, 'type and region, or sp_toplistbrowse, is required'
 
         self._session = session
         self.type = type
@@ -88,9 +86,7 @@ class Toplist(object):
 
         if add_ref:
             lib.sp_toplistbrowse_add_ref(sp_toplistbrowse)
-        self._sp_toplistbrowse = ffi.gc(
-            sp_toplistbrowse, lib.sp_toplistbrowse_release
-        )
+        self._sp_toplistbrowse = ffi.gc(sp_toplistbrowse, lib.sp_toplistbrowse_release)
 
     def __repr__(self):
         return 'Toplist(type=%r, region=%r, canonical_username=%r)' % (
@@ -132,9 +128,7 @@ class Toplist(object):
 
         Check to see if there was problems creating the toplist.
         """
-        return spotify.ErrorType(
-            lib.sp_toplistbrowse_error(self._sp_toplistbrowse)
-        )
+        return spotify.ErrorType(lib.sp_toplistbrowse_error(self._sp_toplistbrowse))
 
     @property
     def backend_request_duration(self):
@@ -146,9 +140,7 @@ class Toplist(object):
         """
         if not self.is_loaded:
             return None
-        return lib.sp_toplistbrowse_backend_request_duration(
-            self._sp_toplistbrowse
-        )
+        return lib.sp_toplistbrowse_backend_request_duration(self._sp_toplistbrowse)
 
     @property
     @serialized
@@ -238,8 +230,7 @@ def _toplistbrowse_complete_callback(sp_toplistbrowse, handle):
     logger.debug('toplistbrowse_complete_callback called')
     if handle == ffi.NULL:
         logger.warning(
-            'pyspotify toplistbrowse_complete_callback '
-            'called without userdata'
+            'pyspotify toplistbrowse_complete_callback ' 'called without userdata'
         )
         return
     (session, toplist, callback) = ffi.from_handle(handle)

--- a/spotify/toplist.py
+++ b/spotify/toplist.py
@@ -6,7 +6,7 @@ import threading
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-__all__ = ['Toplist', 'ToplistRegion', 'ToplistType']
+__all__ = ["Toplist", "ToplistRegion", "ToplistType"]
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +57,7 @@ class Toplist(object):
 
         assert (
             type is not None and region is not None
-        ) or sp_toplistbrowse, 'type and region, or sp_toplistbrowse, is required'
+        ) or sp_toplistbrowse, "type and region, or sp_toplistbrowse, is required"
 
         self._session = session
         self.type = type
@@ -89,7 +89,7 @@ class Toplist(object):
         self._sp_toplistbrowse = ffi.gc(sp_toplistbrowse, lib.sp_toplistbrowse_release)
 
     def __repr__(self):
-        return 'Toplist(type=%r, region=%r, canonical_username=%r)' % (
+        return "Toplist(type=%r, region=%r, canonical_username=%r)" % (
             self.type,
             self.region,
             self.canonical_username,
@@ -224,13 +224,13 @@ class Toplist(object):
         )
 
 
-@ffi.callback('void(sp_toplistbrowse *, void *)')
+@ffi.callback("void(sp_toplistbrowse *, void *)")
 @serialized
 def _toplistbrowse_complete_callback(sp_toplistbrowse, handle):
-    logger.debug('toplistbrowse_complete_callback called')
+    logger.debug("toplistbrowse_complete_callback called")
     if handle == ffi.NULL:
         logger.warning(
-            'pyspotify toplistbrowse_complete_callback ' 'called without userdata'
+            "pyspotify toplistbrowse_complete_callback " "called without userdata"
         )
         return
     (session, toplist, callback) = ffi.from_handle(handle)
@@ -240,11 +240,11 @@ def _toplistbrowse_complete_callback(sp_toplistbrowse, handle):
         callback(toplist)
 
 
-@utils.make_enum('SP_TOPLIST_REGION_')
+@utils.make_enum("SP_TOPLIST_REGION_")
 class ToplistRegion(utils.IntEnum):
     pass
 
 
-@utils.make_enum('SP_TOPLIST_TYPE_')
+@utils.make_enum("SP_TOPLIST_TYPE_")
 class ToplistType(utils.IntEnum):
     pass

--- a/spotify/toplist.py
+++ b/spotify/toplist.py
@@ -6,7 +6,6 @@ import threading
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-
 __all__ = ['Toplist', 'ToplistRegion', 'ToplistType']
 
 logger = logging.getLogger(__name__)

--- a/spotify/track.py
+++ b/spotify/track.py
@@ -28,9 +28,7 @@ class Track(object):
         if uri is not None:
             track = spotify.Link(self._session, uri=uri).as_track()
             if track is None:
-                raise ValueError(
-                    'Failed to get track from Spotify URI: %r' % uri
-                )
+                raise ValueError('Failed to get track from Spotify URI: %r' % uri)
             sp_track = track._sp_track
             add_ref = True
 
@@ -85,14 +83,10 @@ class Track(object):
 
         Will always return :class:`None` if the track isn't loaded.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return None
-        return TrackOfflineStatus(
-            lib.sp_track_offline_get_status(self._sp_track)
-        )
+        return TrackOfflineStatus(lib.sp_track_offline_get_status(self._sp_track))
 
     @property
     def availability(self):
@@ -100,15 +94,11 @@ class Track(object):
 
         Will always return :class:`None` if the track isn't loaded.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return None
         return TrackAvailability(
-            lib.sp_track_get_availability(
-                self._session._sp_session, self._sp_track
-            )
+            lib.sp_track_get_availability(self._session._sp_session, self._sp_track)
         )
 
     @property
@@ -117,14 +107,10 @@ class Track(object):
 
         Will always return :class:`None` if the track isn't loaded.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return None
-        return bool(
-            lib.sp_track_is_local(self._session._sp_session, self._sp_track)
-        )
+        return bool(lib.sp_track_is_local(self._session._sp_session, self._sp_track))
 
     @property
     def is_autolinked(self):
@@ -134,15 +120,11 @@ class Track(object):
 
         See :attr:`playable`.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return None
         return bool(
-            lib.sp_track_is_autolinked(
-                self._session._sp_session, self._sp_track
-            )
+            lib.sp_track_is_autolinked(self._session._sp_session, self._sp_track)
         )
 
     @property
@@ -154,9 +136,7 @@ class Track(object):
 
         See :attr:`is_autolinked`.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return None
         return Track(
@@ -187,9 +167,7 @@ class Track(object):
 
         Will always return :class:`None` if the track isn't loaded.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return None
         return bool(lib.sp_track_is_placeholder(self._sp_track))
@@ -202,14 +180,10 @@ class Track(object):
 
         Will always be :class:`None` if the track isn't loaded.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return None
-        return bool(
-            lib.sp_track_is_starred(self._session._sp_session, self._sp_track)
-        )
+        return bool(lib.sp_track_is_starred(self._session._sp_session, self._sp_track))
 
     @starred.setter
     def starred(self, value):
@@ -228,9 +202,7 @@ class Track(object):
 
         Will always return an empty list if the track isn't loaded.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return []
 
@@ -257,9 +229,7 @@ class Track(object):
 
         Will always return :class:`None` if the track isn't loaded.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return None
         sp_album = lib.sp_track_album(self._sp_track)
@@ -272,9 +242,7 @@ class Track(object):
 
         Will always return :class:`None` if the track isn't loaded.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return None
         return utils.to_unicode(lib.sp_track_name(self._sp_track))
@@ -285,9 +253,7 @@ class Track(object):
 
         Will always return :class:`None` if the track isn't loaded.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return None
         return lib.sp_track_duration(self._sp_track)
@@ -298,9 +264,7 @@ class Track(object):
 
         Will always return :class:`None` if the track isn't loaded.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return None
         return lib.sp_track_popularity(self._sp_track)
@@ -312,9 +276,7 @@ class Track(object):
         Will always return :class:`None` if the track isn't part of an album or
         artist browser.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return None
         return lib.sp_track_disc(self._sp_track)
@@ -326,9 +288,7 @@ class Track(object):
         Will always return :class:`None` if the track isn't part of an album or
         artist browser.
         """
-        spotify.Error.maybe_raise(
-            self.error, ignores=[spotify.ErrorType.IS_LOADING]
-        )
+        spotify.Error.maybe_raise(self.error, ignores=[spotify.ErrorType.IS_LOADING])
         if not self.is_loaded:
             return None
         return lib.sp_track_index(self._sp_track)

--- a/spotify/track.py
+++ b/spotify/track.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-
 __all__ = ['Track', 'TrackAvailability', 'TrackOfflineStatus']
 
 

--- a/spotify/track.py
+++ b/spotify/track.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-__all__ = ['Track', 'TrackAvailability', 'TrackOfflineStatus']
+__all__ = ["Track", "TrackAvailability", "TrackOfflineStatus"]
 
 
 class Track(object):
@@ -21,14 +21,14 @@ class Track(object):
     """
 
     def __init__(self, session, uri=None, sp_track=None, add_ref=True):
-        assert uri or sp_track, 'uri or sp_track is required'
+        assert uri or sp_track, "uri or sp_track is required"
 
         self._session = session
 
         if uri is not None:
             track = spotify.Link(self._session, uri=uri).as_track()
             if track is None:
-                raise ValueError('Failed to get track from Spotify URI: %r' % uri)
+                raise ValueError("Failed to get track from Spotify URI: %r" % uri)
             sp_track = track._sp_track
             add_ref = True
 
@@ -37,7 +37,7 @@ class Track(object):
         self._sp_track = ffi.gc(sp_track, lib.sp_track_release)
 
     def __repr__(self):
-        return 'Track(%r)' % self.link.uri
+        return "Track(%r)" % self.link.uri
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -187,7 +187,7 @@ class Track(object):
 
     @starred.setter
     def starred(self, value):
-        tracks = ffi.new('sp_track *[]', 1)
+        tracks = ffi.new("sp_track *[]", 1)
         tracks[0] = self._sp_track
         spotify.Error.maybe_raise(
             lib.sp_track_set_starred(
@@ -308,11 +308,11 @@ class Track(object):
         )
 
 
-@utils.make_enum('SP_TRACK_AVAILABILITY_')
+@utils.make_enum("SP_TRACK_AVAILABILITY_")
 class TrackAvailability(utils.IntEnum):
     pass
 
 
-@utils.make_enum('SP_TRACK_OFFLINE_')
+@utils.make_enum("SP_TRACK_OFFLINE_")
 class TrackOfflineStatus(utils.IntEnum):
     pass

--- a/spotify/user.py
+++ b/spotify/user.py
@@ -28,9 +28,7 @@ class User(object):
         if uri is not None:
             user = spotify.Link(self._session, uri=uri).as_user()
             if user is None:
-                raise ValueError(
-                    'Failed to get user from Spotify URI: %r' % uri
-                )
+                raise ValueError('Failed to get user from Spotify URI: %r' % uri)
             sp_user = user._sp_user
             add_ref = True
 

--- a/spotify/user.py
+++ b/spotify/user.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-__all__ = ['User']
+__all__ = ["User"]
 
 
 class User(object):
@@ -21,14 +21,14 @@ class User(object):
     """
 
     def __init__(self, session, uri=None, sp_user=None, add_ref=True):
-        assert uri or sp_user, 'uri or sp_user is required'
+        assert uri or sp_user, "uri or sp_user is required"
 
         self._session = session
 
         if uri is not None:
             user = spotify.Link(self._session, uri=uri).as_user()
             if user is None:
-                raise ValueError('Failed to get user from Spotify URI: %r' % uri)
+                raise ValueError("Failed to get user from Spotify URI: %r" % uri)
             sp_user = user._sp_user
             add_ref = True
 
@@ -37,7 +37,7 @@ class User(object):
         self._sp_user = ffi.gc(sp_user, lib.sp_user_release)
 
     def __repr__(self):
-        return 'User(%r)' % self.link.uri
+        return "User(%r)" % self.link.uri
 
     @property
     @serialized

--- a/spotify/user.py
+++ b/spotify/user.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import spotify
 from spotify import ffi, lib, serialized, utils
 
-
 __all__ = ['User']
 
 

--- a/spotify/utils.py
+++ b/spotify/utils.py
@@ -88,7 +88,7 @@ class EventEmitter(object):
         # when registering the second listener instead of when the event is
         # emitted.
         assert self.num_listeners(event) == 1, (
-            'Expected exactly 1 event listener, found %d listeners'
+            "Expected exactly 1 event listener, found %d listeners"
             % self.num_listeners(event)
         )
         listener = self._listeners[event][0]
@@ -96,7 +96,7 @@ class EventEmitter(object):
         return listener.callback(*args)
 
 
-class _Listener(collections.namedtuple('Listener', ['callback', 'user_args'])):
+class _Listener(collections.namedtuple("Listener", ["callback", "user_args"])):
 
     """An listener of events from an :class:`EventEmitter`"""
 
@@ -110,17 +110,17 @@ class IntEnum(int):
     """
 
     def __new__(cls, value):
-        if not hasattr(cls, '_values'):
+        if not hasattr(cls, "_values"):
             cls._values = {}
         if value not in cls._values:
             cls._values[value] = int.__new__(cls, value)
         return cls._values[value]
 
     def __repr__(self):
-        if hasattr(self, '_name'):
-            return '<%s.%s: %d>' % (self.__class__.__name__, self._name, self)
+        if hasattr(self, "_name"):
+            return "<%s.%s: %d>" % (self.__class__.__name__, self._name, self)
         else:
-            return '<Unknown %s: %d>' % (self.__class__.__name__, self)
+            return "<Unknown %s: %d>" % (self.__class__.__name__, self)
 
     @classmethod
     def add(cls, name, value):
@@ -130,7 +130,7 @@ class IntEnum(int):
         setattr(cls, name, attr)
 
 
-def make_enum(lib_prefix, enum_prefix=''):
+def make_enum(lib_prefix, enum_prefix=""):
     """Class decorator for automatically adding enum values.
 
     The values are read directly from the :attr:`spotify.lib` CFFI wrapper
@@ -158,7 +158,7 @@ def get_with_fixed_buffer(buffer_length, func, *args):
     Returns the buffer's value decoded from UTF-8 to a unicode string.
     """
     func = functools.partial(func, *args)
-    buffer_ = ffi.new('char[]', buffer_length)
+    buffer_ = ffi.new("char[]", buffer_length)
     func(buffer_, buffer_length)
     return to_unicode(buffer_)
 
@@ -180,7 +180,7 @@ def get_with_growing_buffer(func, *args):
     buffer_length = actual_length
     while actual_length >= buffer_length:
         buffer_length = actual_length + 1
-        buffer_ = ffi.new('char[]', buffer_length)
+        buffer_ = ffi.new("char[]", buffer_length)
         actual_length = func(buffer_, buffer_length)
     if actual_length == -1:
         return None
@@ -188,7 +188,7 @@ def get_with_growing_buffer(func, *args):
 
 
 def _check_error(obj):
-    error_type = getattr(obj, 'error', spotify.ErrorType.OK)
+    error_type = getattr(obj, "error", spotify.ErrorType.OK)
     spotify.Error.maybe_raise(error_type, ignores=[spotify.ErrorType.IS_LOADING])
 
 
@@ -216,7 +216,7 @@ def load(session, obj, timeout=None):
 
     if session.connection.state is not spotify.ConnectionState.LOGGED_IN:
         raise spotify.Error(
-            'Session must be logged in and online to load objects: %r'
+            "Session must be logged in and online to load objects: %r"
             % session.connection.state
         )
 
@@ -269,16 +269,16 @@ class Sequence(compat.Sequence):
             return list(self).__getitem__(key)
         if not isinstance(key, int):
             raise TypeError(
-                'list indices must be int or slice, not %s' % key.__class__.__name__
+                "list indices must be int or slice, not %s" % key.__class__.__name__
             )
         if key < 0:
             key += self.__len__()
         if not 0 <= key < self.__len__():
-            raise IndexError('list index out of range')
+            raise IndexError("list index out of range")
         return self._getitem_func(self._sp_obj, key)
 
     def __repr__(self):
-        return '%s(%s)' % (self.__class__.__name__, pprint.pformat(list(self)))
+        return "%s(%s)" % (self.__class__.__name__, pprint.pformat(list(self)))
 
 
 def to_bytes(value):
@@ -287,13 +287,13 @@ def to_bytes(value):
     Unicode strings are encoded to UTF-8.
     """
     if isinstance(value, compat.text_type):
-        return value.encode('utf-8')
+        return value.encode("utf-8")
     elif isinstance(value, ffi.CData):
         return ffi.string(value)
     elif isinstance(value, compat.binary_type):
         return value
     else:
-        raise ValueError('Value must be text, bytes, or char[]')
+        raise ValueError("Value must be text, bytes, or char[]")
 
 
 def to_bytes_or_none(value):
@@ -303,7 +303,7 @@ def to_bytes_or_none(value):
     elif isinstance(value, ffi.CData):
         return ffi.string(value)
     else:
-        raise ValueError('Value must be char[] or NULL')
+        raise ValueError("Value must be char[] or NULL")
 
 
 def to_unicode(value):
@@ -312,13 +312,13 @@ def to_unicode(value):
     Bytes and C char arrays are decoded from UTF-8.
     """
     if isinstance(value, ffi.CData):
-        return ffi.string(value).decode('utf-8')
+        return ffi.string(value).decode("utf-8")
     elif isinstance(value, compat.binary_type):
-        return value.decode('utf-8')
+        return value.decode("utf-8")
     elif isinstance(value, compat.text_type):
         return value
     else:
-        raise ValueError('Value must be text, bytes, or char[]')
+        raise ValueError("Value must be text, bytes, or char[]")
 
 
 def to_unicode_or_none(value):
@@ -329,14 +329,14 @@ def to_unicode_or_none(value):
     if value == ffi.NULL:
         return None
     elif isinstance(value, ffi.CData):
-        return ffi.string(value).decode('utf-8')
+        return ffi.string(value).decode("utf-8")
     else:
-        raise ValueError('Value must be char[] or NULL')
+        raise ValueError("Value must be char[] or NULL")
 
 
 def to_char(value):
     """Converts bytes, unicode, and C char arrays to C char arrays.  """
-    return ffi.new('char[]', to_bytes(value))
+    return ffi.new("char[]", to_bytes(value))
 
 
 def to_char_or_null(value):
@@ -361,8 +361,8 @@ def to_country_code(country):
     """
     country = to_unicode(country)
     if len(country) != 2:
-        raise ValueError('Must be exactly two chars')
+        raise ValueError("Must be exactly two chars")
     first, second = (ord(char) for char in country)
-    if not (ord('A') <= first <= ord('Z')) or not (ord('A') <= second <= ord('Z')):
-        raise ValueError('Chars must be in range A-Z')
+    if not (ord("A") <= first <= ord("Z")) or not (ord("A") <= second <= ord("Z")):
+        raise ValueError("Chars must be in range A-Z")
     return first << 8 | second

--- a/spotify/utils.py
+++ b/spotify/utils.py
@@ -27,9 +27,7 @@ class EventEmitter(object):
         If the listener function returns :class:`False`, it is removed and will
         not be called the next time the ``event`` is emitted.
         """
-        self._listeners[event].append(
-            _Listener(callback=listener, user_args=user_args)
-        )
+        self._listeners[event].append(_Listener(callback=listener, user_args=user_args))
 
     @serialized
     def off(self, event=None, listener=None):
@@ -191,9 +189,7 @@ def get_with_growing_buffer(func, *args):
 
 def _check_error(obj):
     error_type = getattr(obj, 'error', spotify.ErrorType.OK)
-    spotify.Error.maybe_raise(
-        error_type, ignores=[spotify.ErrorType.IS_LOADING]
-    )
+    spotify.Error.maybe_raise(error_type, ignores=[spotify.ErrorType.IS_LOADING])
 
 
 def load(session, obj, timeout=None):
@@ -258,9 +254,7 @@ class Sequence(compat.Sequence):
     when the ``sp_obj`` object is GC-ed.
     """
 
-    def __init__(
-        self, sp_obj, add_ref_func, release_func, len_func, getitem_func
-    ):
+    def __init__(self, sp_obj, add_ref_func, release_func, len_func, getitem_func):
 
         add_ref_func(sp_obj)
         self._sp_obj = ffi.gc(sp_obj, release_func)
@@ -275,8 +269,7 @@ class Sequence(compat.Sequence):
             return list(self).__getitem__(key)
         if not isinstance(key, int):
             raise TypeError(
-                'list indices must be int or slice, not %s'
-                % key.__class__.__name__
+                'list indices must be int or slice, not %s' % key.__class__.__name__
             )
         if key < 0:
             key += self.__len__()
@@ -370,8 +363,6 @@ def to_country_code(country):
     if len(country) != 2:
         raise ValueError('Must be exactly two chars')
     first, second = (ord(char) for char in country)
-    if not (ord('A') <= first <= ord('Z')) or not (
-        ord('A') <= second <= ord('Z')
-    ):
+    if not (ord('A') <= first <= ord('Z')) or not (ord('A') <= second <= ord('Z')):
         raise ValueError('Chars must be in range A-Z')
     return first << 8 | second

--- a/tasks.py
+++ b/tasks.py
@@ -7,14 +7,14 @@ from invoke import task
 
 @task
 def docs(ctx, warn=False):
-    ctx.run('make -C docs/ html', warn=warn)
+    ctx.run("make -C docs/ html", warn=warn)
 
 
 @task
 def test(ctx, coverage=False, warn=False):
-    cmd = 'py.test'
+    cmd = "py.test"
     if coverage:
-        cmd += ' --cov=spotify --cov-report=term-missing'
+        cmd += " --cov=spotify --cov-report=term-missing"
     ctx.run(cmd, pty=True, warn=warn)
 
 
@@ -22,7 +22,7 @@ def test(ctx, coverage=False, warn=False):
 def preprocess_header(ctx):
     ctx.run(
         'cpp -nostdinc spotify/api.h | egrep -v "(^#)|(^$)" '
-        '> spotify/api.processed.h || true'
+        "> spotify/api.processed.h || true"
     )
 
 
@@ -37,11 +37,11 @@ def update_sp_constants(ctx):
     import spotify
 
     constants = [
-        '%s,%s\n' % (attr, getattr(spotify.lib, attr))
+        "%s,%s\n" % (attr, getattr(spotify.lib, attr))
         for attr in dir(spotify.lib)
-        if attr.startswith('SP_')
+        if attr.startswith("SP_")
     ]
-    with open('docs/sp-constants.csv', 'w+') as fh:
+    with open("docs/sp-constants.csv", "w+") as fh:
         fh.writelines(constants)
 
 
@@ -59,23 +59,23 @@ def mac_wheels(ctx):
 
     versions = [
         # Python.org Python 2.7 for Mac OS X 10.6 and later
-        '/Library/Frameworks/Python.framework/Versions/2.7/bin/python',
+        "/Library/Frameworks/Python.framework/Versions/2.7/bin/python",
         # Python.org Python 3.7 for Mac OS X 10.6 and later
-        '/Library/Frameworks/Python.framework/Versions/3.7/bin/python3',
+        "/Library/Frameworks/Python.framework/Versions/3.7/bin/python3",
         # Homebrew Python 2.7
-        '/usr/local/bin/python2.7',
+        "/usr/local/bin/python2.7",
         # Homebrew Python 3.7
-        '/usr/local/bin/python3.7',
+        "/usr/local/bin/python3.7",
     ]
 
     # Build wheels for all Python versions
     for executable in versions:
-        shutil.rmtree('./build', ignore_errors=True)
-        ctx.run('%s -m pip install wheel' % executable)
-        ctx.run('%s setup.py bdist_wheel' % executable)
+        shutil.rmtree("./build", ignore_errors=True)
+        ctx.run("%s -m pip install wheel" % executable)
+        ctx.run("%s setup.py bdist_wheel" % executable)
 
     # Bundle libspotify into the wheels
-    shutil.rmtree('./fixed_dist', ignore_errors=True)
-    ctx.run('delocate-wheel -w ./fixed_dist ./dist/*.whl')
+    shutil.rmtree("./fixed_dist", ignore_errors=True)
+    ctx.run("delocate-wheel -w ./fixed_dist ./dist/*.whl")
 
-    print('To upload wheels, run: twine upload fixed_dist/*')
+    print("To upload wheels, run: twine upload fixed_dist/*")

--- a/tasks.py
+++ b/tasks.py
@@ -29,9 +29,7 @@ def preprocess_header(ctx):
 @task
 def update_authors(ctx):
     # Keep authors in the order of appearance and use awk to filter out dupes
-    ctx.run(
-        "git log --format='- %aN <%aE>' --reverse | awk '!x[$0]++' > AUTHORS"
-    )
+    ctx.run("git log --format='- %aN <%aE>' --reverse | awk '!x[$0]++' > AUTHORS")
 
 
 @task

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -30,7 +30,7 @@ def buffer_writer(string):
         # Due to Python 3 treating bytes as an array of ints, we have to
         # encode and copy chars one by one.
         for i in range(length):
-            buffer_[i] = string[i].encode('utf-8')
+            buffer_[i] = string[i].encode("utf-8")
 
         return len(string)
 
@@ -41,7 +41,7 @@ def create_real_session(lib_mock):
     """Create a real :class:`spotify.Session` using ``lib_mock``."""
     lib_mock.sp_session_create.return_value = spotify.ErrorType.OK
     config = spotify.Config()
-    config.application_key = b'\x01' * 321
+    config.application_key = b"\x01" * 321
     return spotify.Session(config=config)
 
 
@@ -63,7 +63,7 @@ def gc_collect():
     # computer running the tests. This skips them all for now.
     raise unittest.SkipTest
 
-    if platform.python_implementation() == 'PyPy':
+    if platform.python_implementation() == "PyPy":
         # Since PyPy use garbage collection instead of reference counting
         # objects are not finalized before the next major GC collection.
         # Currently, the best way we have to ensure a major GC collection has

--- a/tests/regression/bug_119.py
+++ b/tests/regression/bug_119.py
@@ -7,7 +7,6 @@ import time
 
 import spotify
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/regression/bug_119.py
+++ b/tests/regression/bug_119.py
@@ -11,16 +11,16 @@ logger = logging.getLogger(__name__)
 
 
 ALBUMS = [
-    'spotify:album:02Zb13fM8k04tRwTfMUhe9',  # OK
-    'spotify:album:3ph1ceuYuayuzoIJzPQji2',  # Fails
-    'spotify:album:4IBQvwIbtDluogvDe2qpaB',  # Fails
-    'spotify:album:5VppVyy751PTQWrfJbrJ4H',  # Fails
-    'spotify:album:2cRMVS71c49Pf5SnIlJX3U',  # OK
-    'spotify:album:6mulYcpWRDAiv7KIouWvyP',  # OK
-    'spotify:album:02jqf49ws9bcTvXLPGtjbT',  # Fails
-    'spotify:album:17orrZznh0gmxYtpNP47nK',  # Fails
-    'spotify:album:5lnQLEUiVDkLbFJHXHQu9m',  # Fails
-    'spotify:album:3ph1ceuYuayuzoIJzPQji2',  # Fails
+    "spotify:album:02Zb13fM8k04tRwTfMUhe9",  # OK
+    "spotify:album:3ph1ceuYuayuzoIJzPQji2",  # Fails
+    "spotify:album:4IBQvwIbtDluogvDe2qpaB",  # Fails
+    "spotify:album:5VppVyy751PTQWrfJbrJ4H",  # Fails
+    "spotify:album:2cRMVS71c49Pf5SnIlJX3U",  # OK
+    "spotify:album:6mulYcpWRDAiv7KIouWvyP",  # OK
+    "spotify:album:02jqf49ws9bcTvXLPGtjbT",  # Fails
+    "spotify:album:17orrZznh0gmxYtpNP47nK",  # Fails
+    "spotify:album:5lnQLEUiVDkLbFJHXHQu9m",  # Fails
+    "spotify:album:3ph1ceuYuayuzoIJzPQji2",  # Fails
 ]
 
 
@@ -41,7 +41,7 @@ def login(session, username, password):
     session.login(username, password)
 
     if not logged_in_event.wait(10):
-        raise RuntimeError('Login timed out')
+        raise RuntimeError("Login timed out")
 
     while session.connection.state != spotify.ConnectionState.LOGGED_IN:
         time.sleep(0.1)
@@ -57,24 +57,24 @@ def logout(session):
     session.logout()
 
     if not logged_out_event.wait(10):
-        raise RuntimeError('Logout timed out')
+        raise RuntimeError("Logout timed out")
 
 
 def get_albums(session):
-    logger.info('Getting albums')
+    logger.info("Getting albums")
     for uri in ALBUMS:
-        logger.info('Loading %s...', uri)
+        logger.info("Loading %s...", uri)
         try:
             album = session.get_album(uri)
             # album.browse()  # Add this line, and everything works
             logger.info(album.load(3).name)
         except spotify.Timeout:
-            logger.warning('Timeout')
+            logger.warning("Timeout")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if len(sys.argv) != 3:
-        sys.exit('Usage: %s USERNAME PASSWORD' % sys.argv[0])
+        sys.exit("Usage: %s USERNAME PASSWORD" % sys.argv[0])
 
     logging.basicConfig(level=logging.INFO)
 

--- a/tests/regression/bug_122.py
+++ b/tests/regression/bug_122.py
@@ -7,7 +7,6 @@ import time
 
 import spotify
 
-
 if len(sys.argv) != 3:
     sys.exit('Usage: %s USERNAME PASSWORD' % sys.argv[0])
 

--- a/tests/regression/bug_122.py
+++ b/tests/regression/bug_122.py
@@ -39,9 +39,7 @@ loop.start()
 login(session, username, password)
 
 logger.debug('Getting playlist')
-pl = session.get_playlist(
-    'spotify:user:durden20:playlist:1chOHrXPCFcShCwB357MFX'
-)
+pl = session.get_playlist('spotify:user:durden20:playlist:1chOHrXPCFcShCwB357MFX')
 logger.debug('Got playlist %r %r', pl, pl._sp_playlist)
 logger.debug('Loading playlist %r %r', pl, pl._sp_playlist)
 pl.load()

--- a/tests/regression/bug_122.py
+++ b/tests/regression/bug_122.py
@@ -8,7 +8,7 @@ import time
 import spotify
 
 if len(sys.argv) != 3:
-    sys.exit('Usage: %s USERNAME PASSWORD' % sys.argv[0])
+    sys.exit("Usage: %s USERNAME PASSWORD" % sys.argv[0])
 
 username, password = sys.argv[1], sys.argv[2]
 
@@ -23,7 +23,7 @@ def login(session, username, password):
     session.login(username, password)
 
     if not logged_in_event.wait(10):
-        raise RuntimeError('Login timed out')
+        raise RuntimeError("Login timed out")
 
     while session.connection.state != spotify.ConnectionState.LOGGED_IN:
         time.sleep(0.1)
@@ -38,12 +38,12 @@ loop.start()
 
 login(session, username, password)
 
-logger.debug('Getting playlist')
-pl = session.get_playlist('spotify:user:durden20:playlist:1chOHrXPCFcShCwB357MFX')
-logger.debug('Got playlist %r %r', pl, pl._sp_playlist)
-logger.debug('Loading playlist %r %r', pl, pl._sp_playlist)
+logger.debug("Getting playlist")
+pl = session.get_playlist("spotify:user:durden20:playlist:1chOHrXPCFcShCwB357MFX")
+logger.debug("Got playlist %r %r", pl, pl._sp_playlist)
+logger.debug("Loading playlist %r %r", pl, pl._sp_playlist)
 pl.load()
-logger.debug('Loaded playlist %r %r', pl, pl._sp_playlist)
+logger.debug("Loaded playlist %r %r", pl, pl._sp_playlist)
 
 print(pl)
 print(pl.tracks)

--- a/tests/regression/bug_123.py
+++ b/tests/regression/bug_123.py
@@ -15,36 +15,36 @@ logger = logging.getLogger(__name__)
 def make_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '-u',
-        '--username',
-        action='store',
+        "-u",
+        "--username",
+        action="store",
         required=True,
-        help='Spotify username',
+        help="Spotify username",
     )
     parser.add_argument(
-        '-p',
-        '--password',
-        action='store',
+        "-p",
+        "--password",
+        action="store",
         required=True,
-        help='Spotify password',
+        help="Spotify password",
     )
     parser.add_argument(
-        '-v', '--verbose', action='store_true', help='Turn on debug logging'
+        "-v", "--verbose", action="store_true", help="Turn on debug logging"
     )
-    subparsers = parser.add_subparsers(dest='command', help='sub-command --help')
+    subparsers = parser.add_subparsers(dest="command", help="sub-command --help")
 
-    subparsers.add_parser('info', help='Get account info')
+    subparsers.add_parser("info", help="Get account info")
 
     create_playlist_parser = subparsers.add_parser(
-        'create-playlist', help='Create a new playlist'
+        "create-playlist", help="Create a new playlist"
     )
     create_playlist_parser.add_argument(
-        'name', action='store', help='Name of new playlist'
+        "name", action="store", help="Name of new playlist"
     )
 
-    add_track_parser = subparsers.add_parser('add-track', help='Add track to playlist')
-    add_track_parser.add_argument('playlist', action='store', help='URI of playlist')
-    add_track_parser.add_argument('track', action='store', help='URI of track')
+    add_track_parser = subparsers.add_parser("add-track", help="Add track to playlist")
+    add_track_parser.add_argument("playlist", action="store", help="URI of playlist")
+    add_track_parser.add_argument("track", action="store", help="URI of track")
 
     return parser
 
@@ -54,18 +54,18 @@ def login(session, username, password):
 
     def logged_in_listener(session, error_type):
         if error_type != spotify.ErrorType.OK:
-            logger.error('Login failed: %r', error_type)
+            logger.error("Login failed: %r", error_type)
         logged_in_event.set()
 
     session.on(spotify.SessionEvent.LOGGED_IN, logged_in_listener)
     session.login(username, password)
 
     if not logged_in_event.wait(10):
-        raise RuntimeError('Login timed out')
-    logger.debug('Logged in as %r', session.user_name)
+        raise RuntimeError("Login timed out")
+    logger.debug("Logged in as %r", session.user_name)
 
     while session.connection.state != spotify.ConnectionState.LOGGED_IN:
-        logger.debug('Waiting for connection')
+        logger.debug("Waiting for connection")
         time.sleep(0.1)
 
 
@@ -79,7 +79,7 @@ def logout(session):
     session.logout()
 
     if not logged_out_event.wait(10):
-        raise RuntimeError('Logout timed out')
+        raise RuntimeError("Logout timed out")
 
 
 def create_playlist(session, playlist_name):
@@ -108,37 +108,37 @@ def main(args):
     login(session, args.username, args.password)
 
     try:
-        if args.command == 'info':
+        if args.command == "info":
             session.playlist_container.load()
             result = {
-                'success': True,
-                'action': args.command,
-                'response': {
-                    'user_name': session.user_name,
-                    'num_playlists': len(session.playlist_container),
-                    'num_starred': len(session.starred.tracks),
+                "success": True,
+                "action": args.command,
+                "response": {
+                    "user_name": session.user_name,
+                    "num_playlists": len(session.playlist_container),
+                    "num_starred": len(session.starred.tracks),
                 },
             }
-        elif args.command == 'create-playlist':
+        elif args.command == "create-playlist":
             name, uri = create_playlist(session, args.name)
             result = {
-                'success': True,
-                'action': args.command,
-                'response': {'playlist_name': name, 'playlist_uri': uri},
+                "success": True,
+                "action": args.command,
+                "response": {"playlist_name": name, "playlist_uri": uri},
             }
-        elif args.command == 'add-track':
+        elif args.command == "add-track":
             playlist_uri, track_uri = add_track(session, args.playlist, args.track)
             result = {
-                'success': True,
-                'action': args.command,
-                'response': {
-                    'playlist_uri': playlist_uri,
-                    'track_uri': track_uri,
+                "success": True,
+                "action": args.command,
+                "response": {
+                    "playlist_uri": playlist_uri,
+                    "track_uri": track_uri,
                 },
             }
     except spotify.Error as error:
-        logger.exception('%s failed', args.command)
-        result = {'success': False, 'action': args.command, 'error': str(error)}
+        logger.exception("%s failed", args.command)
+        result = {"success": False, "action": args.command, "error": str(error)}
 
     # Proper logout ensures that all data is persisted properly
     logout(session)
@@ -146,9 +146,9 @@ def main(args):
     return result
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = make_parser()
     args = parser.parse_args()
     result = main(args)
     print(json.dumps(result, indent=2))
-    sys.exit(not result['success'])
+    sys.exit(not result["success"])

--- a/tests/regression/bug_123.py
+++ b/tests/regression/bug_123.py
@@ -31,9 +31,7 @@ def make_parser():
     parser.add_argument(
         '-v', '--verbose', action='store_true', help='Turn on debug logging'
     )
-    subparsers = parser.add_subparsers(
-        dest='command', help='sub-command --help'
-    )
+    subparsers = parser.add_subparsers(dest='command', help='sub-command --help')
 
     subparsers.add_parser('info', help='Get account info')
 
@@ -44,12 +42,8 @@ def make_parser():
         'name', action='store', help='Name of new playlist'
     )
 
-    add_track_parser = subparsers.add_parser(
-        'add-track', help='Add track to playlist'
-    )
-    add_track_parser.add_argument(
-        'playlist', action='store', help='URI of playlist'
-    )
+    add_track_parser = subparsers.add_parser('add-track', help='Add track to playlist')
+    add_track_parser.add_argument('playlist', action='store', help='URI of playlist')
     add_track_parser.add_argument('track', action='store', help='URI of track')
 
     return parser
@@ -133,9 +127,7 @@ def main(args):
                 'response': {'playlist_name': name, 'playlist_uri': uri},
             }
         elif args.command == 'add-track':
-            playlist_uri, track_uri = add_track(
-                session, args.playlist, args.track
-            )
+            playlist_uri, track_uri = add_track(session, args.playlist, args.track)
             result = {
                 'success': True,
                 'action': args.command,

--- a/tests/regression/bug_123.py
+++ b/tests/regression/bug_123.py
@@ -9,7 +9,6 @@ import time
 
 import spotify
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/regression/failing_link_to_playlist.py
+++ b/tests/regression/failing_link_to_playlist.py
@@ -18,17 +18,17 @@ session.relogin()
 while session.connection.state != spotify.ConnectionState.LOGGED_IN:
     session.process_events()
 
-user = session.get_user('spotify:user:p3.no').load()
+user = session.get_user("spotify:user:p3.no").load()
 user.published_playlists.load()
 
 time.sleep(10)
 session.process_events()
 
-print('%d playlists found' % len(user.published_playlists))
+print("%d playlists found" % len(user.published_playlists))
 
 for playlist in user.published_playlists:
     playlist.load()
-    print('Loaded', playlist)
+    print("Loaded", playlist)
 
 print(user.published_playlists)
 

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -223,9 +223,7 @@ class AlbumTest(unittest.TestCase):
         lib_mock.sp_link_create_from_album_cover.assert_called_once_with(
             sp_album, int(image_size)
         )
-        link_mock.assert_called_once_with(
-            self.session, sp_link=sp_link, add_ref=False
-        )
+        link_mock.assert_called_once_with(self.session, sp_link=sp_link, add_ref=False)
         self.assertEqual(result, mock.sentinel.link)
 
     @mock.patch('spotify.Link', spec=spotify.Link)
@@ -243,9 +241,7 @@ class AlbumTest(unittest.TestCase):
         )
 
     def test_name(self, lib_mock):
-        lib_mock.sp_album_name.return_value = spotify.ffi.new(
-            'char[]', b'Foo Bar Baz'
-        )
+        lib_mock.sp_album_name.return_value = spotify.ffi.new('char[]', b'Foo Bar Baz')
         sp_album = spotify.ffi.cast('sp_album *', 42)
         album = spotify.Album(self.session, sp_album=sp_album)
 
@@ -314,9 +310,7 @@ class AlbumTest(unittest.TestCase):
 
         result = album.link
 
-        link_mock.assert_called_once_with(
-            self.session, sp_link=sp_link, add_ref=False
-        )
+        link_mock.assert_called_once_with(self.session, sp_link=sp_link, add_ref=False)
         self.assertEqual(result, mock.sentinel.link)
 
 
@@ -378,9 +372,7 @@ class AlbumBrowserTest(unittest.TestCase):
         lib_mock.sp_albumbrowse_create.return_value = sp_albumbrowse
         callback = mock.Mock()
 
-        result = spotify.AlbumBrowser(
-            self.session, album=album, callback=callback
-        )
+        result = spotify.AlbumBrowser(self.session, album=album, callback=callback)
         loaded_event = result.loaded_event
         result = None  # noqa
         tests.gc_collect()
@@ -393,9 +385,7 @@ class AlbumBrowserTest(unittest.TestCase):
 
         loaded_event.wait(3)
         self.assertEqual(callback.call_count, 1)
-        self.assertEqual(
-            callback.call_args[0][0]._sp_albumbrowse, sp_albumbrowse
-        )
+        self.assertEqual(callback.call_args[0][0]._sp_albumbrowse, sp_albumbrowse)
 
     def test_adds_ref_to_sp_albumbrowse_when_created(self, lib_mock):
         session = tests.create_session_mock()
@@ -408,9 +398,7 @@ class AlbumBrowserTest(unittest.TestCase):
     def test_releases_sp_albumbrowse_when_album_dies(self, lib_mock):
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
 
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
         browser = None  # noqa
         tests.gc_collect()
 
@@ -419,9 +407,7 @@ class AlbumBrowserTest(unittest.TestCase):
     @mock.patch('spotify.Link', spec=spotify.Link)
     def test_repr(self, link_mock, lib_mock):
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
         lib_mock.sp_albumbrowse_is_loaded.return_value = 1
         sp_album = spotify.ffi.cast('sp_album *', 43)
         lib_mock.sp_albumbrowse_album.return_value = sp_album
@@ -434,9 +420,7 @@ class AlbumBrowserTest(unittest.TestCase):
 
     def test_repr_if_unloaded(self, lib_mock):
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
         lib_mock.sp_albumbrowse_is_loaded.return_value = 0
 
         result = repr(browser)
@@ -445,58 +429,40 @@ class AlbumBrowserTest(unittest.TestCase):
 
     def test_eq(self, lib_mock):
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser1 = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
-        browser2 = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser1 = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
+        browser2 = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         self.assertTrue(browser1 == browser2)
         self.assertFalse(browser1 == 'foo')
 
     def test_ne(self, lib_mock):
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser1 = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
-        browser2 = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser1 = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
+        browser2 = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         self.assertFalse(browser1 != browser2)
 
     def test_hash(self, lib_mock):
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser1 = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
-        browser2 = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser1 = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
+        browser2 = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         self.assertEqual(hash(browser1), hash(browser2))
 
     def test_is_loaded(self, lib_mock):
         lib_mock.sp_albumbrowse_is_loaded.return_value = 1
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         result = browser.is_loaded
 
-        lib_mock.sp_albumbrowse_is_loaded.assert_called_once_with(
-            sp_albumbrowse
-        )
+        lib_mock.sp_albumbrowse_is_loaded.assert_called_once_with(sp_albumbrowse)
         self.assertTrue(result)
 
     @mock.patch('spotify.utils.load')
     def test_load(self, load_mock, lib_mock):
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         browser.load(10)
 
@@ -507,9 +473,7 @@ class AlbumBrowserTest(unittest.TestCase):
             spotify.ErrorType.OTHER_PERMANENT
         )
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         result = browser.error
 
@@ -519,9 +483,7 @@ class AlbumBrowserTest(unittest.TestCase):
     def test_backend_request_duration(self, lib_mock):
         lib_mock.sp_albumbrowse_backend_request_duration.return_value = 137
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         result = browser.backend_request_duration
 
@@ -533,23 +495,17 @@ class AlbumBrowserTest(unittest.TestCase):
     def test_backend_request_duration_when_not_loaded(self, lib_mock):
         lib_mock.sp_albumbrowse_is_loaded.return_value = 0
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         result = browser.backend_request_duration
 
         lib_mock.sp_albumbrowse_is_loaded.assert_called_with(sp_albumbrowse)
-        self.assertEqual(
-            lib_mock.sp_albumbrowse_backend_request_duration.call_count, 0
-        )
+        self.assertEqual(lib_mock.sp_albumbrowse_backend_request_duration.call_count, 0)
         self.assertIsNone(result)
 
     def test_album(self, lib_mock):
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
         sp_album = spotify.ffi.cast('sp_album *', 43)
         lib_mock.sp_albumbrowse_album.return_value = sp_album
 
@@ -560,9 +516,7 @@ class AlbumBrowserTest(unittest.TestCase):
 
     def test_album_when_not_loaded(self, lib_mock):
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
         lib_mock.sp_albumbrowse_album.return_value = spotify.ffi.NULL
 
         result = browser.album
@@ -573,9 +527,7 @@ class AlbumBrowserTest(unittest.TestCase):
     @mock.patch('spotify.artist.lib', spec=spotify.lib)
     def test_artist(self, artist_lib_mock, lib_mock):
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
         sp_artist = spotify.ffi.cast('sp_artist *', 43)
         lib_mock.sp_albumbrowse_artist.return_value = sp_artist
 
@@ -586,9 +538,7 @@ class AlbumBrowserTest(unittest.TestCase):
 
     def test_artist_when_not_loaded(self, lib_mock):
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
         lib_mock.sp_albumbrowse_artist.return_value = spotify.ffi.NULL
 
         result = browser.artist
@@ -601,18 +551,14 @@ class AlbumBrowserTest(unittest.TestCase):
         lib_mock.sp_albumbrowse_num_copyrights.return_value = 1
         lib_mock.sp_albumbrowse_copyright.return_value = copyright
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         self.assertEqual(lib_mock.sp_albumbrowse_add_ref.call_count, 1)
         result = browser.copyrights
         self.assertEqual(lib_mock.sp_albumbrowse_add_ref.call_count, 2)
 
         self.assertEqual(len(result), 1)
-        lib_mock.sp_albumbrowse_num_copyrights.assert_called_with(
-            sp_albumbrowse
-        )
+        lib_mock.sp_albumbrowse_num_copyrights.assert_called_with(sp_albumbrowse)
 
         item = result[0]
         self.assertIsInstance(item, compat.text_type)
@@ -623,24 +569,18 @@ class AlbumBrowserTest(unittest.TestCase):
     def test_copyrights_if_no_copyrights(self, lib_mock):
         lib_mock.sp_albumbrowse_num_copyrights.return_value = 0
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         result = browser.copyrights
 
         self.assertEqual(len(result), 0)
-        lib_mock.sp_albumbrowse_num_copyrights.assert_called_with(
-            sp_albumbrowse
-        )
+        lib_mock.sp_albumbrowse_num_copyrights.assert_called_with(sp_albumbrowse)
         self.assertEqual(lib_mock.sp_albumbrowse_copyright.call_count, 0)
 
     def test_copyrights_if_unloaded(self, lib_mock):
         lib_mock.sp_albumbrowse_is_loaded.return_value = 0
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         result = browser.copyrights
 
@@ -653,9 +593,7 @@ class AlbumBrowserTest(unittest.TestCase):
         lib_mock.sp_albumbrowse_num_tracks.return_value = 1
         lib_mock.sp_albumbrowse_track.return_value = sp_track
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         self.assertEqual(lib_mock.sp_albumbrowse_add_ref.call_count, 1)
         result = browser.tracks
@@ -674,9 +612,7 @@ class AlbumBrowserTest(unittest.TestCase):
     def test_tracks_if_no_tracks(self, lib_mock):
         lib_mock.sp_albumbrowse_num_tracks.return_value = 0
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         result = browser.tracks
 
@@ -687,9 +623,7 @@ class AlbumBrowserTest(unittest.TestCase):
     def test_tracks_if_unloaded(self, lib_mock):
         lib_mock.sp_albumbrowse_is_loaded.return_value = 0
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         result = browser.tracks
 
@@ -698,9 +632,7 @@ class AlbumBrowserTest(unittest.TestCase):
 
     def test_review(self, lib_mock):
         sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
-        browser = spotify.AlbumBrowser(
-            self.session, sp_albumbrowse=sp_albumbrowse
-        )
+        browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
         review = spotify.ffi.new('char[]', b'A nice album')
         lib_mock.sp_albumbrowse_review.return_value = review
 

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -8,7 +8,7 @@ from spotify import compat
 from tests import mock
 
 
-@mock.patch('spotify.album.lib', spec=spotify.lib)
+@mock.patch("spotify.album.lib", spec=spotify.lib)
 class AlbumTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
@@ -17,14 +17,14 @@ class AlbumTest(unittest.TestCase):
         with self.assertRaises(AssertionError):
             spotify.Album(self.session)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_create_from_uri(self, link_mock, lib_mock):
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         link_instance_mock = link_mock.return_value
         link_instance_mock.as_album.return_value = spotify.Album(
             self.session, sp_album=sp_album
         )
-        uri = 'spotify:album:foo'
+        uri = "spotify:album:foo"
 
         result = spotify.Album(self.session, uri=uri)
 
@@ -33,24 +33,24 @@ class AlbumTest(unittest.TestCase):
         lib_mock.sp_album_add_ref.assert_called_with(sp_album)
         self.assertEqual(result._sp_album, sp_album)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_create_from_uri_fail_raises_error(self, link_mock, lib_mock):
         link_instance_mock = link_mock.return_value
         link_instance_mock.as_album.return_value = None
-        uri = 'spotify:album:foo'
+        uri = "spotify:album:foo"
 
         with self.assertRaises(ValueError):
             spotify.Album(self.session, uri=uri)
 
     def test_adds_ref_to_sp_album_when_created(self, lib_mock):
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
 
         spotify.Album(self.session, sp_album=sp_album)
 
         lib_mock.sp_album_add_ref.assert_called_with(sp_album)
 
     def test_releases_sp_album_when_album_dies(self, lib_mock):
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
 
         album = spotify.Album(self.session, sp_album=sp_album)
         album = None  # noqa
@@ -58,34 +58,34 @@ class AlbumTest(unittest.TestCase):
 
         lib_mock.sp_album_release.assert_called_with(sp_album)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_repr(self, link_mock, lib_mock):
         link_instance_mock = link_mock.return_value
-        link_instance_mock.uri = 'foo'
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        link_instance_mock.uri = "foo"
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
 
         result = repr(album)
 
-        self.assertEqual(result, 'Album(%r)' % 'foo')
+        self.assertEqual(result, "Album(%r)" % "foo")
 
     def test_eq(self, lib_mock):
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album1 = spotify.Album(self.session, sp_album=sp_album)
         album2 = spotify.Album(self.session, sp_album=sp_album)
 
         self.assertTrue(album1 == album2)
-        self.assertFalse(album1 == 'foo')
+        self.assertFalse(album1 == "foo")
 
     def test_ne(self, lib_mock):
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album1 = spotify.Album(self.session, sp_album=sp_album)
         album2 = spotify.Album(self.session, sp_album=sp_album)
 
         self.assertFalse(album1 != album2)
 
     def test_hash(self, lib_mock):
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album1 = spotify.Album(self.session, sp_album=sp_album)
         album2 = spotify.Album(self.session, sp_album=sp_album)
 
@@ -93,7 +93,7 @@ class AlbumTest(unittest.TestCase):
 
     def test_is_loaded(self, lib_mock):
         lib_mock.sp_album_is_loaded.return_value = 1
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
 
         result = album.is_loaded
@@ -101,9 +101,9 @@ class AlbumTest(unittest.TestCase):
         lib_mock.sp_album_is_loaded.assert_called_once_with(sp_album)
         self.assertTrue(result)
 
-    @mock.patch('spotify.utils.load')
+    @mock.patch("spotify.utils.load")
     def test_load(self, load_mock, lib_mock):
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
 
         album.load(10)
@@ -112,7 +112,7 @@ class AlbumTest(unittest.TestCase):
 
     def test_is_available(self, lib_mock):
         lib_mock.sp_album_is_available.return_value = 1
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
 
         result = album.is_available
@@ -122,7 +122,7 @@ class AlbumTest(unittest.TestCase):
 
     def test_is_available_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_album_is_loaded.return_value = 0
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
 
         result = album.is_available
@@ -130,11 +130,11 @@ class AlbumTest(unittest.TestCase):
         lib_mock.sp_album_is_loaded.assert_called_once_with(sp_album)
         self.assertIsNone(result)
 
-    @mock.patch('spotify.artist.lib', spec=spotify.lib)
+    @mock.patch("spotify.artist.lib", spec=spotify.lib)
     def test_artist(self, artist_lib_mock, lib_mock):
-        sp_artist = spotify.ffi.cast('sp_artist *', 43)
+        sp_artist = spotify.ffi.cast("sp_artist *", 43)
         lib_mock.sp_album_artist.return_value = sp_artist
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
 
         result = album.artist
@@ -144,10 +144,10 @@ class AlbumTest(unittest.TestCase):
         self.assertIsInstance(result, spotify.Artist)
         self.assertEqual(result._sp_artist, sp_artist)
 
-    @mock.patch('spotify.artist.lib', spec=spotify.lib)
+    @mock.patch("spotify.artist.lib", spec=spotify.lib)
     def test_artist_if_unloaded(self, artist_lib_mock, lib_mock):
         lib_mock.sp_album_artist.return_value = spotify.ffi.NULL
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
 
         result = album.artist
@@ -155,13 +155,13 @@ class AlbumTest(unittest.TestCase):
         lib_mock.sp_album_artist.assert_called_with(sp_album)
         self.assertIsNone(result)
 
-    @mock.patch('spotify.Image', spec=spotify.Image)
+    @mock.patch("spotify.Image", spec=spotify.Image)
     def test_cover(self, image_mock, lib_mock):
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
-        sp_image_id = spotify.ffi.new('char[]', b'cover-id')
+        sp_image_id = spotify.ffi.new("char[]", b"cover-id")
         lib_mock.sp_album_cover.return_value = sp_image_id
-        sp_image = spotify.ffi.cast('sp_image *', 43)
+        sp_image = spotify.ffi.cast("sp_image *", 43)
         lib_mock.sp_image_create.return_value = sp_image
         image_mock.return_value = mock.sentinel.image
         image_size = spotify.ImageSize.SMALL
@@ -182,13 +182,13 @@ class AlbumTest(unittest.TestCase):
             self.session, sp_image=sp_image, add_ref=False, callback=callback
         )
 
-    @mock.patch('spotify.Image', spec=spotify.Image)
+    @mock.patch("spotify.Image", spec=spotify.Image)
     def test_cover_defaults_to_normal_size(self, image_mock, lib_mock):
-        sp_image_id = spotify.ffi.new('char[]', b'cover-id')
+        sp_image_id = spotify.ffi.new("char[]", b"cover-id")
         lib_mock.sp_album_cover.return_value = sp_image_id
-        sp_image = spotify.ffi.cast('sp_image *', 43)
+        sp_image = spotify.ffi.cast("sp_image *", 43)
         lib_mock.sp_image_create.return_value = sp_image
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
 
         album.cover()
@@ -199,7 +199,7 @@ class AlbumTest(unittest.TestCase):
 
     def test_cover_is_none_if_null(self, lib_mock):
         lib_mock.sp_album_cover.return_value = spotify.ffi.NULL
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
 
         result = album.cover()
@@ -209,11 +209,11 @@ class AlbumTest(unittest.TestCase):
         )
         self.assertIsNone(result)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_cover_link_creates_link_to_cover(self, link_mock, lib_mock):
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
-        sp_link = spotify.ffi.cast('sp_link *', 43)
+        sp_link = spotify.ffi.cast("sp_link *", 43)
         lib_mock.sp_link_create_from_album_cover.return_value = sp_link
         link_mock.return_value = mock.sentinel.link
         image_size = spotify.ImageSize.SMALL
@@ -226,11 +226,11 @@ class AlbumTest(unittest.TestCase):
         link_mock.assert_called_once_with(self.session, sp_link=sp_link, add_ref=False)
         self.assertEqual(result, mock.sentinel.link)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_cover_link_defaults_to_normal_size(self, link_mock, lib_mock):
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
-        sp_link = spotify.ffi.cast('sp_link *', 43)
+        sp_link = spotify.ffi.cast("sp_link *", 43)
         lib_mock.sp_link_create_from_album_cover.return_value = sp_link
         link_mock.return_value = mock.sentinel.link
 
@@ -241,18 +241,18 @@ class AlbumTest(unittest.TestCase):
         )
 
     def test_name(self, lib_mock):
-        lib_mock.sp_album_name.return_value = spotify.ffi.new('char[]', b'Foo Bar Baz')
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        lib_mock.sp_album_name.return_value = spotify.ffi.new("char[]", b"Foo Bar Baz")
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
 
         result = album.name
 
         lib_mock.sp_album_name.assert_called_once_with(sp_album)
-        self.assertEqual(result, 'Foo Bar Baz')
+        self.assertEqual(result, "Foo Bar Baz")
 
     def test_name_is_none_if_unloaded(self, lib_mock):
-        lib_mock.sp_album_name.return_value = spotify.ffi.new('char[]', b'')
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        lib_mock.sp_album_name.return_value = spotify.ffi.new("char[]", b"")
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
 
         result = album.name
@@ -262,7 +262,7 @@ class AlbumTest(unittest.TestCase):
 
     def test_year(self, lib_mock):
         lib_mock.sp_album_year.return_value = 2013
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
 
         result = album.year
@@ -272,7 +272,7 @@ class AlbumTest(unittest.TestCase):
 
     def test_year_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_album_is_loaded.return_value = 0
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
 
         result = album.year
@@ -282,7 +282,7 @@ class AlbumTest(unittest.TestCase):
 
     def test_type(self, lib_mock):
         lib_mock.sp_album_type.return_value = int(spotify.AlbumType.SINGLE)
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
 
         result = album.type
@@ -292,7 +292,7 @@ class AlbumTest(unittest.TestCase):
 
     def test_type_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_album_is_loaded.return_value = 0
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
 
         result = album.type
@@ -300,11 +300,11 @@ class AlbumTest(unittest.TestCase):
         lib_mock.sp_album_is_loaded.assert_called_once_with(sp_album)
         self.assertIsNone(result)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_link_creates_link_to_album(self, link_mock, lib_mock):
-        sp_album = spotify.ffi.cast('sp_album *', 42)
+        sp_album = spotify.ffi.cast("sp_album *", 42)
         album = spotify.Album(self.session, sp_album=sp_album)
-        sp_link = spotify.ffi.cast('sp_link *', 43)
+        sp_link = spotify.ffi.cast("sp_link *", 43)
         lib_mock.sp_link_create_from_album.return_value = sp_link
         link_mock.return_value = mock.sentinel.link
 
@@ -314,7 +314,7 @@ class AlbumTest(unittest.TestCase):
         self.assertEqual(result, mock.sentinel.link)
 
 
-@mock.patch('spotify.album.lib', spec=spotify.lib)
+@mock.patch("spotify.album.lib", spec=spotify.lib)
 class AlbumBrowserTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
@@ -328,9 +328,9 @@ class AlbumBrowserTest(unittest.TestCase):
             spotify.AlbumBrowser(self.session)
 
     def test_create_from_album(self, lib_mock):
-        sp_album = spotify.ffi.cast('sp_album *', 43)
+        sp_album = spotify.ffi.cast("sp_album *", 43)
         album = spotify.Album(self.session, sp_album=sp_album)
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         lib_mock.sp_albumbrowse_create.return_value = sp_albumbrowse
 
         result = album.browse()
@@ -347,9 +347,9 @@ class AlbumBrowserTest(unittest.TestCase):
         self.assertTrue(result.loaded_event.is_set())
 
     def test_create_from_album_with_callback(self, lib_mock):
-        sp_album = spotify.ffi.cast('sp_album *', 43)
+        sp_album = spotify.ffi.cast("sp_album *", 43)
         album = spotify.Album(self.session, sp_album=sp_album)
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         lib_mock.sp_albumbrowse_create.return_value = sp_albumbrowse
         callback = mock.Mock()
 
@@ -366,9 +366,9 @@ class AlbumBrowserTest(unittest.TestCase):
         callback.assert_called_with(result)
 
     def test_browser_is_gone_before_callback_is_called(self, lib_mock):
-        sp_album = spotify.ffi.cast('sp_album *', 43)
+        sp_album = spotify.ffi.cast("sp_album *", 43)
         album = spotify.Album(self.session, sp_album=sp_album)
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         lib_mock.sp_albumbrowse_create.return_value = sp_albumbrowse
         callback = mock.Mock()
 
@@ -389,14 +389,14 @@ class AlbumBrowserTest(unittest.TestCase):
 
     def test_adds_ref_to_sp_albumbrowse_when_created(self, lib_mock):
         session = tests.create_session_mock()
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
 
         spotify.AlbumBrowser(session, sp_albumbrowse=sp_albumbrowse)
 
         lib_mock.sp_albumbrowse_add_ref.assert_called_with(sp_albumbrowse)
 
     def test_releases_sp_albumbrowse_when_album_dies(self, lib_mock):
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
 
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
         browser = None  # noqa
@@ -404,46 +404,46 @@ class AlbumBrowserTest(unittest.TestCase):
 
         lib_mock.sp_albumbrowse_release.assert_called_with(sp_albumbrowse)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_repr(self, link_mock, lib_mock):
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
         lib_mock.sp_albumbrowse_is_loaded.return_value = 1
-        sp_album = spotify.ffi.cast('sp_album *', 43)
+        sp_album = spotify.ffi.cast("sp_album *", 43)
         lib_mock.sp_albumbrowse_album.return_value = sp_album
         link_instance_mock = link_mock.return_value
-        link_instance_mock.uri = 'foo'
+        link_instance_mock.uri = "foo"
 
         result = repr(browser)
 
-        self.assertEqual(result, 'AlbumBrowser(%r)' % 'foo')
+        self.assertEqual(result, "AlbumBrowser(%r)" % "foo")
 
     def test_repr_if_unloaded(self, lib_mock):
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
         lib_mock.sp_albumbrowse_is_loaded.return_value = 0
 
         result = repr(browser)
 
-        self.assertEqual(result, 'AlbumBrowser(<not loaded>)')
+        self.assertEqual(result, "AlbumBrowser(<not loaded>)")
 
     def test_eq(self, lib_mock):
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser1 = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
         browser2 = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         self.assertTrue(browser1 == browser2)
-        self.assertFalse(browser1 == 'foo')
+        self.assertFalse(browser1 == "foo")
 
     def test_ne(self, lib_mock):
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser1 = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
         browser2 = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         self.assertFalse(browser1 != browser2)
 
     def test_hash(self, lib_mock):
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser1 = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
         browser2 = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
@@ -451,7 +451,7 @@ class AlbumBrowserTest(unittest.TestCase):
 
     def test_is_loaded(self, lib_mock):
         lib_mock.sp_albumbrowse_is_loaded.return_value = 1
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         result = browser.is_loaded
@@ -459,9 +459,9 @@ class AlbumBrowserTest(unittest.TestCase):
         lib_mock.sp_albumbrowse_is_loaded.assert_called_once_with(sp_albumbrowse)
         self.assertTrue(result)
 
-    @mock.patch('spotify.utils.load')
+    @mock.patch("spotify.utils.load")
     def test_load(self, load_mock, lib_mock):
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         browser.load(10)
@@ -472,7 +472,7 @@ class AlbumBrowserTest(unittest.TestCase):
         lib_mock.sp_albumbrowse_error.return_value = int(
             spotify.ErrorType.OTHER_PERMANENT
         )
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         result = browser.error
@@ -482,7 +482,7 @@ class AlbumBrowserTest(unittest.TestCase):
 
     def test_backend_request_duration(self, lib_mock):
         lib_mock.sp_albumbrowse_backend_request_duration.return_value = 137
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         result = browser.backend_request_duration
@@ -494,7 +494,7 @@ class AlbumBrowserTest(unittest.TestCase):
 
     def test_backend_request_duration_when_not_loaded(self, lib_mock):
         lib_mock.sp_albumbrowse_is_loaded.return_value = 0
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         result = browser.backend_request_duration
@@ -504,9 +504,9 @@ class AlbumBrowserTest(unittest.TestCase):
         self.assertIsNone(result)
 
     def test_album(self, lib_mock):
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
-        sp_album = spotify.ffi.cast('sp_album *', 43)
+        sp_album = spotify.ffi.cast("sp_album *", 43)
         lib_mock.sp_albumbrowse_album.return_value = sp_album
 
         result = browser.album
@@ -515,7 +515,7 @@ class AlbumBrowserTest(unittest.TestCase):
         self.assertEqual(result._sp_album, sp_album)
 
     def test_album_when_not_loaded(self, lib_mock):
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
         lib_mock.sp_albumbrowse_album.return_value = spotify.ffi.NULL
 
@@ -524,11 +524,11 @@ class AlbumBrowserTest(unittest.TestCase):
         lib_mock.sp_albumbrowse_album.assert_called_with(sp_albumbrowse)
         self.assertIsNone(result)
 
-    @mock.patch('spotify.artist.lib', spec=spotify.lib)
+    @mock.patch("spotify.artist.lib", spec=spotify.lib)
     def test_artist(self, artist_lib_mock, lib_mock):
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
-        sp_artist = spotify.ffi.cast('sp_artist *', 43)
+        sp_artist = spotify.ffi.cast("sp_artist *", 43)
         lib_mock.sp_albumbrowse_artist.return_value = sp_artist
 
         result = browser.artist
@@ -537,7 +537,7 @@ class AlbumBrowserTest(unittest.TestCase):
         self.assertEqual(result._sp_artist, sp_artist)
 
     def test_artist_when_not_loaded(self, lib_mock):
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
         lib_mock.sp_albumbrowse_artist.return_value = spotify.ffi.NULL
 
@@ -547,10 +547,10 @@ class AlbumBrowserTest(unittest.TestCase):
         self.assertIsNone(result)
 
     def test_copyrights(self, lib_mock):
-        copyright = spotify.ffi.new('char[]', b'Apple Records 1973')
+        copyright = spotify.ffi.new("char[]", b"Apple Records 1973")
         lib_mock.sp_albumbrowse_num_copyrights.return_value = 1
         lib_mock.sp_albumbrowse_copyright.return_value = copyright
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         self.assertEqual(lib_mock.sp_albumbrowse_add_ref.call_count, 1)
@@ -562,13 +562,13 @@ class AlbumBrowserTest(unittest.TestCase):
 
         item = result[0]
         self.assertIsInstance(item, compat.text_type)
-        self.assertEqual(item, 'Apple Records 1973')
+        self.assertEqual(item, "Apple Records 1973")
         self.assertEqual(lib_mock.sp_albumbrowse_copyright.call_count, 1)
         lib_mock.sp_albumbrowse_copyright.assert_called_with(sp_albumbrowse, 0)
 
     def test_copyrights_if_no_copyrights(self, lib_mock):
         lib_mock.sp_albumbrowse_num_copyrights.return_value = 0
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         result = browser.copyrights
@@ -579,7 +579,7 @@ class AlbumBrowserTest(unittest.TestCase):
 
     def test_copyrights_if_unloaded(self, lib_mock):
         lib_mock.sp_albumbrowse_is_loaded.return_value = 0
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         result = browser.copyrights
@@ -587,12 +587,12 @@ class AlbumBrowserTest(unittest.TestCase):
         lib_mock.sp_albumbrowse_is_loaded.assert_called_with(sp_albumbrowse)
         self.assertEqual(len(result), 0)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_tracks(self, track_lib_mock, lib_mock):
-        sp_track = spotify.ffi.cast('sp_track *', 43)
+        sp_track = spotify.ffi.cast("sp_track *", 43)
         lib_mock.sp_albumbrowse_num_tracks.return_value = 1
         lib_mock.sp_albumbrowse_track.return_value = sp_track
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         self.assertEqual(lib_mock.sp_albumbrowse_add_ref.call_count, 1)
@@ -611,7 +611,7 @@ class AlbumBrowserTest(unittest.TestCase):
 
     def test_tracks_if_no_tracks(self, lib_mock):
         lib_mock.sp_albumbrowse_num_tracks.return_value = 0
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         result = browser.tracks
@@ -622,7 +622,7 @@ class AlbumBrowserTest(unittest.TestCase):
 
     def test_tracks_if_unloaded(self, lib_mock):
         lib_mock.sp_albumbrowse_is_loaded.return_value = 0
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
 
         result = browser.tracks
@@ -631,15 +631,15 @@ class AlbumBrowserTest(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
     def test_review(self, lib_mock):
-        sp_albumbrowse = spotify.ffi.cast('sp_albumbrowse *', 42)
+        sp_albumbrowse = spotify.ffi.cast("sp_albumbrowse *", 42)
         browser = spotify.AlbumBrowser(self.session, sp_albumbrowse=sp_albumbrowse)
-        review = spotify.ffi.new('char[]', b'A nice album')
+        review = spotify.ffi.new("char[]", b"A nice album")
         lib_mock.sp_albumbrowse_review.return_value = review
 
         result = browser.review
 
         self.assertIsInstance(result, compat.text_type)
-        self.assertEqual(result, 'A nice album')
+        self.assertEqual(result, "A nice album")
 
 
 class AlbumTypeTest(unittest.TestCase):

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -3,9 +3,8 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-from spotify import compat
-
 import tests
+from spotify import compat
 from tests import mock
 
 

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -94,9 +94,7 @@ class ArtistTest(unittest.TestCase):
         self.assertEqual(hash(artist1), hash(artist2))
 
     def test_name(self, lib_mock):
-        lib_mock.sp_artist_name.return_value = spotify.ffi.new(
-            'char[]', b'Foo Bar Baz'
-        )
+        lib_mock.sp_artist_name.return_value = spotify.ffi.new('char[]', b'Foo Bar Baz')
         sp_artist = spotify.ffi.cast('sp_artist *', 42)
         artist = spotify.Artist(self.session, sp_artist=sp_artist)
 
@@ -149,9 +147,7 @@ class ArtistTest(unittest.TestCase):
         result = artist.portrait(image_size, callback=callback)
 
         self.assertIs(result, mock.sentinel.image)
-        lib_mock.sp_artist_portrait.assert_called_with(
-            sp_artist, int(image_size)
-        )
+        lib_mock.sp_artist_portrait.assert_called_with(sp_artist, int(image_size))
         lib_mock.sp_image_create.assert_called_with(
             self.session._sp_session, sp_image_id
         )
@@ -204,9 +200,7 @@ class ArtistTest(unittest.TestCase):
         lib_mock.sp_link_create_from_artist_portrait.assert_called_once_with(
             sp_artist, int(image_size)
         )
-        link_mock.assert_called_once_with(
-            self.session, sp_link=sp_link, add_ref=False
-        )
+        link_mock.assert_called_once_with(self.session, sp_link=sp_link, add_ref=False)
         self.assertEqual(result, mock.sentinel.link)
 
     @mock.patch('spotify.Link', spec=spotify.Link)
@@ -233,9 +227,7 @@ class ArtistTest(unittest.TestCase):
 
         result = artist.link
 
-        link_mock.assert_called_once_with(
-            self.session, sp_link=sp_link, add_ref=False
-        )
+        link_mock.assert_called_once_with(self.session, sp_link=sp_link, add_ref=False)
         self.assertEqual(result, mock.sentinel.link)
 
 
@@ -269,9 +261,7 @@ class ArtistBrowserTest(unittest.TestCase):
         )
         self.assertIsInstance(result, spotify.ArtistBrowser)
 
-        artistbrowse_complete_cb = lib_mock.sp_artistbrowse_create.call_args[0][
-            3
-        ]
+        artistbrowse_complete_cb = lib_mock.sp_artistbrowse_create.call_args[0][3]
         userdata = lib_mock.sp_artistbrowse_create.call_args[0][4]
         self.assertFalse(result.loaded_event.is_set())
         artistbrowse_complete_cb(sp_artistbrowse, userdata)
@@ -295,9 +285,7 @@ class ArtistBrowserTest(unittest.TestCase):
             mock.ANY,
             mock.ANY,
         )
-        artistbrowse_complete_cb = lib_mock.sp_artistbrowse_create.call_args[0][
-            3
-        ]
+        artistbrowse_complete_cb = lib_mock.sp_artistbrowse_create.call_args[0][3]
         userdata = lib_mock.sp_artistbrowse_create.call_args[0][4]
         artistbrowse_complete_cb(sp_artistbrowse, userdata)
 
@@ -311,26 +299,20 @@ class ArtistBrowserTest(unittest.TestCase):
         lib_mock.sp_artistbrowse_create.return_value = sp_artistbrowse
         callback = mock.Mock()
 
-        result = spotify.ArtistBrowser(
-            self.session, artist=artist, callback=callback
-        )
+        result = spotify.ArtistBrowser(self.session, artist=artist, callback=callback)
         loaded_event = result.loaded_event
         result = None  # noqa
         tests.gc_collect()
 
         # The mock keeps the handle/userdata alive, thus this test doesn't
         # really test that session._callback_handles keeps the handle alive.
-        artistbrowse_complete_cb = lib_mock.sp_artistbrowse_create.call_args[0][
-            3
-        ]
+        artistbrowse_complete_cb = lib_mock.sp_artistbrowse_create.call_args[0][3]
         userdata = lib_mock.sp_artistbrowse_create.call_args[0][4]
         artistbrowse_complete_cb(sp_artistbrowse, userdata)
 
         loaded_event.wait(3)
         self.assertEqual(callback.call_count, 1)
-        self.assertEqual(
-            callback.call_args[0][0]._sp_artistbrowse, sp_artistbrowse
-        )
+        self.assertEqual(callback.call_args[0][0]._sp_artistbrowse, sp_artistbrowse)
 
     def test_adds_ref_to_sp_artistbrowse_when_created(self, lib_mock):
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
@@ -342,9 +324,7 @@ class ArtistBrowserTest(unittest.TestCase):
     def test_releases_sp_artistbrowse_when_artist_dies(self, lib_mock):
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
 
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
         browser = None  # noqa
         tests.gc_collect()
 
@@ -353,9 +333,7 @@ class ArtistBrowserTest(unittest.TestCase):
     @mock.patch('spotify.Link', spec=spotify.Link)
     def test_repr(self, link_mock, lib_mock):
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
         lib_mock.sp_artistbrowse_is_loaded.return_value = 1
         sp_artist = spotify.ffi.cast('sp_artist *', 42)
         lib_mock.sp_artistbrowse_artist.return_value = sp_artist
@@ -368,9 +346,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_repr_if_unloaded(self, lib_mock):
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
         lib_mock.sp_artistbrowse_is_loaded.return_value = 0
 
         result = repr(browser)
@@ -379,58 +355,40 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_eq(self, lib_mock):
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser1 = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
-        browser2 = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser1 = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
+        browser2 = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         self.assertTrue(browser1 == browser2)
         self.assertFalse(browser1 == 'foo')
 
     def test_ne(self, lib_mock):
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser1 = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
-        browser2 = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser1 = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
+        browser2 = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         self.assertFalse(browser1 != browser2)
 
     def test_hash(self, lib_mock):
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser1 = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
-        browser2 = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser1 = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
+        browser2 = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         self.assertEqual(hash(browser1), hash(browser2))
 
     def test_is_loaded(self, lib_mock):
         lib_mock.sp_artistbrowse_is_loaded.return_value = 1
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.is_loaded
 
-        lib_mock.sp_artistbrowse_is_loaded.assert_called_once_with(
-            sp_artistbrowse
-        )
+        lib_mock.sp_artistbrowse_is_loaded.assert_called_once_with(sp_artistbrowse)
         self.assertTrue(result)
 
     @mock.patch('spotify.utils.load')
     def test_load(self, load_mock, lib_mock):
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         browser.load(10)
 
@@ -441,9 +399,7 @@ class ArtistBrowserTest(unittest.TestCase):
             spotify.ErrorType.OTHER_PERMANENT
         )
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.error
 
@@ -453,9 +409,7 @@ class ArtistBrowserTest(unittest.TestCase):
     def test_backend_request_duration(self, lib_mock):
         lib_mock.sp_artistbrowse_backend_request_duration.return_value = 137
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.backend_request_duration
 
@@ -467,9 +421,7 @@ class ArtistBrowserTest(unittest.TestCase):
     def test_backend_request_duration_when_not_loaded(self, lib_mock):
         lib_mock.sp_artistbrowse_is_loaded.return_value = 0
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.backend_request_duration
 
@@ -481,9 +433,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_artist(self, lib_mock):
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
         sp_artist = spotify.ffi.cast('sp_artist *', 43)
         lib_mock.sp_artistbrowse_artist.return_value = sp_artist
 
@@ -494,9 +444,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_artist_when_not_loaded(self, lib_mock):
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
         lib_mock.sp_artistbrowse_artist.return_value = spotify.ffi.NULL
 
         result = browser.artist
@@ -507,9 +455,7 @@ class ArtistBrowserTest(unittest.TestCase):
     @mock.patch('spotify.Image', spec=spotify.Image)
     def test_portraits(self, image_mock, lib_mock):
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
         lib_mock.sp_artistbrowse_num_portraits.return_value = 1
         image_id = spotify.ffi.new('char[]', b'image-id')
         lib_mock.sp_artistbrowse_portrait.return_value = image_id
@@ -523,9 +469,7 @@ class ArtistBrowserTest(unittest.TestCase):
         self.assertEqual(lib_mock.sp_artistbrowse_add_ref.call_count, 2)
 
         self.assertEqual(len(result), 1)
-        lib_mock.sp_artistbrowse_num_portraits.assert_called_with(
-            sp_artistbrowse
-        )
+        lib_mock.sp_artistbrowse_num_portraits.assert_called_with(sp_artistbrowse)
 
         item = result[0]
         self.assertIs(item, mock.sentinel.image)
@@ -542,24 +486,18 @@ class ArtistBrowserTest(unittest.TestCase):
     def test_portraits_if_no_portraits(self, lib_mock):
         lib_mock.sp_artistbrowse_num_portraits.return_value = 0
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.portraits()
 
         self.assertEqual(len(result), 0)
-        lib_mock.sp_artistbrowse_num_portraits.assert_called_with(
-            sp_artistbrowse
-        )
+        lib_mock.sp_artistbrowse_num_portraits.assert_called_with(sp_artistbrowse)
         self.assertEqual(lib_mock.sp_artistbrowse_portrait.call_count, 0)
 
     def test_portraits_if_unloaded(self, lib_mock):
         lib_mock.sp_artistbrowse_is_loaded.return_value = 0
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.portraits()
 
@@ -572,9 +510,7 @@ class ArtistBrowserTest(unittest.TestCase):
         lib_mock.sp_artistbrowse_num_tracks.return_value = 1
         lib_mock.sp_artistbrowse_track.return_value = sp_track
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         self.assertEqual(lib_mock.sp_artistbrowse_add_ref.call_count, 1)
         result = browser.tracks
@@ -593,9 +529,7 @@ class ArtistBrowserTest(unittest.TestCase):
     def test_tracks_if_no_tracks(self, lib_mock):
         lib_mock.sp_artistbrowse_num_tracks.return_value = 0
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.tracks
 
@@ -606,9 +540,7 @@ class ArtistBrowserTest(unittest.TestCase):
     def test_tracks_if_unloaded(self, lib_mock):
         lib_mock.sp_artistbrowse_is_loaded.return_value = 0
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.tracks
 
@@ -621,49 +553,37 @@ class ArtistBrowserTest(unittest.TestCase):
         lib_mock.sp_artistbrowse_num_tophit_tracks.return_value = 1
         lib_mock.sp_artistbrowse_tophit_track.return_value = sp_track
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         self.assertEqual(lib_mock.sp_artistbrowse_add_ref.call_count, 1)
         result = browser.tophit_tracks
         self.assertEqual(lib_mock.sp_artistbrowse_add_ref.call_count, 2)
 
         self.assertEqual(len(result), 1)
-        lib_mock.sp_artistbrowse_num_tophit_tracks.assert_called_with(
-            sp_artistbrowse
-        )
+        lib_mock.sp_artistbrowse_num_tophit_tracks.assert_called_with(sp_artistbrowse)
 
         item = result[0]
         self.assertIsInstance(item, spotify.Track)
         self.assertEqual(item._sp_track, sp_track)
         self.assertEqual(lib_mock.sp_artistbrowse_tophit_track.call_count, 1)
-        lib_mock.sp_artistbrowse_tophit_track.assert_called_with(
-            sp_artistbrowse, 0
-        )
+        lib_mock.sp_artistbrowse_tophit_track.assert_called_with(sp_artistbrowse, 0)
         track_lib_mock.sp_track_add_ref.assert_called_with(sp_track)
 
     def test_tophit_tracks_if_no_tracks(self, lib_mock):
         lib_mock.sp_artistbrowse_num_tophit_tracks.return_value = 0
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.tophit_tracks
 
         self.assertEqual(len(result), 0)
-        lib_mock.sp_artistbrowse_num_tophit_tracks.assert_called_with(
-            sp_artistbrowse
-        )
+        lib_mock.sp_artistbrowse_num_tophit_tracks.assert_called_with(sp_artistbrowse)
         self.assertEqual(lib_mock.sp_artistbrowse_track.call_count, 0)
 
     def test_tophit_tracks_if_unloaded(self, lib_mock):
         lib_mock.sp_artistbrowse_is_loaded.return_value = 0
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.tophit_tracks
 
@@ -676,9 +596,7 @@ class ArtistBrowserTest(unittest.TestCase):
         lib_mock.sp_artistbrowse_num_albums.return_value = 1
         lib_mock.sp_artistbrowse_album.return_value = sp_album
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         self.assertEqual(lib_mock.sp_artistbrowse_add_ref.call_count, 1)
         result = browser.albums
@@ -697,9 +615,7 @@ class ArtistBrowserTest(unittest.TestCase):
     def test_albums_if_no_albums(self, lib_mock):
         lib_mock.sp_artistbrowse_num_albums.return_value = 0
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.albums
 
@@ -710,9 +626,7 @@ class ArtistBrowserTest(unittest.TestCase):
     def test_albums_if_unloaded(self, lib_mock):
         lib_mock.sp_artistbrowse_is_loaded.return_value = 0
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.albums
 
@@ -724,49 +638,37 @@ class ArtistBrowserTest(unittest.TestCase):
         lib_mock.sp_artistbrowse_num_similar_artists.return_value = 1
         lib_mock.sp_artistbrowse_similar_artist.return_value = sp_artist
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         self.assertEqual(lib_mock.sp_artistbrowse_add_ref.call_count, 1)
         result = browser.similar_artists
         self.assertEqual(lib_mock.sp_artistbrowse_add_ref.call_count, 2)
 
         self.assertEqual(len(result), 1)
-        lib_mock.sp_artistbrowse_num_similar_artists.assert_called_with(
-            sp_artistbrowse
-        )
+        lib_mock.sp_artistbrowse_num_similar_artists.assert_called_with(sp_artistbrowse)
 
         item = result[0]
         self.assertIsInstance(item, spotify.Artist)
         self.assertEqual(item._sp_artist, sp_artist)
         self.assertEqual(lib_mock.sp_artistbrowse_similar_artist.call_count, 1)
-        lib_mock.sp_artistbrowse_similar_artist.assert_called_with(
-            sp_artistbrowse, 0
-        )
+        lib_mock.sp_artistbrowse_similar_artist.assert_called_with(sp_artistbrowse, 0)
         lib_mock.sp_artist_add_ref.assert_called_with(sp_artist)
 
     def test_similar_artists_if_no_artists(self, lib_mock):
         lib_mock.sp_artistbrowse_num_similar_artists.return_value = 0
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.similar_artists
 
         self.assertEqual(len(result), 0)
-        lib_mock.sp_artistbrowse_num_similar_artists.assert_called_with(
-            sp_artistbrowse
-        )
+        lib_mock.sp_artistbrowse_num_similar_artists.assert_called_with(sp_artistbrowse)
         self.assertEqual(lib_mock.sp_artistbrowse_similar_artist.call_count, 0)
 
     def test_similar_artists_if_unloaded(self, lib_mock):
         lib_mock.sp_artistbrowse_is_loaded.return_value = 0
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.similar_artists
 
@@ -775,9 +677,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_biography(self, lib_mock):
         sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
-        browser = spotify.ArtistBrowser(
-            self.session, sp_artistbrowse=sp_artistbrowse
-        )
+        browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
         biography = spotify.ffi.new('char[]', b'Lived, played, and died')
         lib_mock.sp_artistbrowse_biography.return_value = biography
 

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -8,7 +8,7 @@ from spotify import compat
 from tests import mock
 
 
-@mock.patch('spotify.artist.lib', spec=spotify.lib)
+@mock.patch("spotify.artist.lib", spec=spotify.lib)
 class ArtistTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
@@ -17,15 +17,15 @@ class ArtistTest(unittest.TestCase):
         with self.assertRaises(AssertionError):
             spotify.Artist(self.session)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_create_from_uri(self, link_mock, lib_mock):
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
         link_instance_mock = link_mock.return_value
         link_instance_mock.as_artist.return_value = spotify.Artist(
             self.session, sp_artist=sp_artist
         )
         lib_mock.sp_link_as_artist.return_value = sp_artist
-        uri = 'spotify:artist:foo'
+        uri = "spotify:artist:foo"
 
         result = spotify.Artist(self.session, uri=uri)
 
@@ -34,25 +34,25 @@ class ArtistTest(unittest.TestCase):
         lib_mock.sp_artist_add_ref.assert_called_with(sp_artist)
         self.assertEqual(result._sp_artist, sp_artist)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_create_from_uri_fail_raises_error(self, link_mock, lib_mock):
         link_instance_mock = link_mock.return_value
         link_instance_mock.as_artist.return_value = None
         lib_mock.sp_link_as_artist.return_value = spotify.ffi.NULL
-        uri = 'spotify:artist:foo'
+        uri = "spotify:artist:foo"
 
         with self.assertRaises(ValueError):
             spotify.Artist(self.session, uri=uri)
 
     def test_adds_ref_to_sp_artist_when_created(self, lib_mock):
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
 
         spotify.Artist(self.session, sp_artist=sp_artist)
 
         lib_mock.sp_artist_add_ref.assert_called_with(sp_artist)
 
     def test_releases_sp_artist_when_artist_dies(self, lib_mock):
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
 
         artist = spotify.Artist(self.session, sp_artist=sp_artist)
         artist = None  # noqa
@@ -60,52 +60,52 @@ class ArtistTest(unittest.TestCase):
 
         lib_mock.sp_artist_release.assert_called_with(sp_artist)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_repr(self, link_mock, lib_mock):
         link_instance_mock = link_mock.return_value
-        link_instance_mock.uri = 'foo'
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        link_instance_mock.uri = "foo"
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
         artist = spotify.Artist(self.session, sp_artist=sp_artist)
 
         result = repr(artist)
 
-        self.assertEqual(result, 'Artist(%r)' % 'foo')
+        self.assertEqual(result, "Artist(%r)" % "foo")
 
     def test_eq(self, lib_mock):
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
         artist1 = spotify.Artist(self.session, sp_artist=sp_artist)
         artist2 = spotify.Artist(self.session, sp_artist=sp_artist)
 
         self.assertTrue(artist1 == artist2)
-        self.assertFalse(artist1 == 'foo')
+        self.assertFalse(artist1 == "foo")
 
     def test_ne(self, lib_mock):
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
         artist1 = spotify.Artist(self.session, sp_artist=sp_artist)
         artist2 = spotify.Artist(self.session, sp_artist=sp_artist)
 
         self.assertFalse(artist1 != artist2)
 
     def test_hash(self, lib_mock):
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
         artist1 = spotify.Artist(self.session, sp_artist=sp_artist)
         artist2 = spotify.Artist(self.session, sp_artist=sp_artist)
 
         self.assertEqual(hash(artist1), hash(artist2))
 
     def test_name(self, lib_mock):
-        lib_mock.sp_artist_name.return_value = spotify.ffi.new('char[]', b'Foo Bar Baz')
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        lib_mock.sp_artist_name.return_value = spotify.ffi.new("char[]", b"Foo Bar Baz")
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
         artist = spotify.Artist(self.session, sp_artist=sp_artist)
 
         result = artist.name
 
         lib_mock.sp_artist_name.assert_called_once_with(sp_artist)
-        self.assertEqual(result, 'Foo Bar Baz')
+        self.assertEqual(result, "Foo Bar Baz")
 
     def test_name_is_none_if_unloaded(self, lib_mock):
-        lib_mock.sp_artist_name.return_value = spotify.ffi.new('char[]', b'')
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        lib_mock.sp_artist_name.return_value = spotify.ffi.new("char[]", b"")
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
         artist = spotify.Artist(self.session, sp_artist=sp_artist)
 
         result = artist.name
@@ -115,7 +115,7 @@ class ArtistTest(unittest.TestCase):
 
     def test_is_loaded(self, lib_mock):
         lib_mock.sp_artist_is_loaded.return_value = 1
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
         artist = spotify.Artist(self.session, sp_artist=sp_artist)
 
         result = artist.is_loaded
@@ -123,22 +123,22 @@ class ArtistTest(unittest.TestCase):
         lib_mock.sp_artist_is_loaded.assert_called_once_with(sp_artist)
         self.assertTrue(result)
 
-    @mock.patch('spotify.utils.load')
+    @mock.patch("spotify.utils.load")
     def test_load(self, load_mock, lib_mock):
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
         artist = spotify.Artist(self.session, sp_artist=sp_artist)
 
         artist.load(10)
 
         load_mock.assert_called_with(self.session, artist, timeout=10)
 
-    @mock.patch('spotify.Image', spec=spotify.Image)
+    @mock.patch("spotify.Image", spec=spotify.Image)
     def test_portrait(self, image_mock, lib_mock):
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
         artist = spotify.Artist(self.session, sp_artist=sp_artist)
-        sp_image_id = spotify.ffi.new('char[]', b'portrait-id')
+        sp_image_id = spotify.ffi.new("char[]", b"portrait-id")
         lib_mock.sp_artist_portrait.return_value = sp_image_id
-        sp_image = spotify.ffi.cast('sp_image *', 43)
+        sp_image = spotify.ffi.cast("sp_image *", 43)
         lib_mock.sp_image_create.return_value = sp_image
         image_mock.return_value = mock.sentinel.image
         image_size = spotify.ImageSize.SMALL
@@ -159,13 +159,13 @@ class ArtistTest(unittest.TestCase):
             self.session, sp_image=sp_image, add_ref=False, callback=callback
         )
 
-    @mock.patch('spotify.Image', spec=spotify.Image)
+    @mock.patch("spotify.Image", spec=spotify.Image)
     def test_portrait_defaults_to_normal_size(self, image_mock, lib_mock):
-        sp_image_id = spotify.ffi.new('char[]', b'portrait-id')
+        sp_image_id = spotify.ffi.new("char[]", b"portrait-id")
         lib_mock.sp_artist_portrait.return_value = sp_image_id
-        sp_image = spotify.ffi.cast('sp_image *', 43)
+        sp_image = spotify.ffi.cast("sp_image *", 43)
         lib_mock.sp_image_create.return_value = sp_image
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
         artist = spotify.Artist(self.session, sp_artist=sp_artist)
 
         artist.portrait()
@@ -176,7 +176,7 @@ class ArtistTest(unittest.TestCase):
 
     def test_portrait_is_none_if_null(self, lib_mock):
         lib_mock.sp_artist_portrait.return_value = spotify.ffi.NULL
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
         artist = spotify.Artist(self.session, sp_artist=sp_artist)
 
         result = artist.portrait()
@@ -186,11 +186,11 @@ class ArtistTest(unittest.TestCase):
         )
         self.assertIsNone(result)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_portrait_link_creates_link_to_portrait(self, link_mock, lib_mock):
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
         artist = spotify.Artist(self.session, sp_artist=sp_artist)
-        sp_link = spotify.ffi.cast('sp_link *', 43)
+        sp_link = spotify.ffi.cast("sp_link *", 43)
         lib_mock.sp_link_create_from_artist_portrait.return_value = sp_link
         link_mock.return_value = mock.sentinel.link
         image_size = spotify.ImageSize.SMALL
@@ -203,11 +203,11 @@ class ArtistTest(unittest.TestCase):
         link_mock.assert_called_once_with(self.session, sp_link=sp_link, add_ref=False)
         self.assertEqual(result, mock.sentinel.link)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_portrait_link_defaults_to_normal_size(self, link_mock, lib_mock):
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
         artist = spotify.Artist(self.session, sp_artist=sp_artist)
-        sp_link = spotify.ffi.cast('sp_link *', 43)
+        sp_link = spotify.ffi.cast("sp_link *", 43)
         lib_mock.sp_link_create_from_artist_portrait.return_value = sp_link
         link_mock.return_value = mock.sentinel.link
 
@@ -217,11 +217,11 @@ class ArtistTest(unittest.TestCase):
             sp_artist, int(spotify.ImageSize.NORMAL)
         )
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_link_creates_link_to_artist(self, link_mock, lib_mock):
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
         artist = spotify.Artist(self.session, sp_artist=sp_artist)
-        sp_link = spotify.ffi.cast('sp_link *', 43)
+        sp_link = spotify.ffi.cast("sp_link *", 43)
         lib_mock.sp_link_create_from_artist.return_value = sp_link
         link_mock.return_value = mock.sentinel.link
 
@@ -231,7 +231,7 @@ class ArtistTest(unittest.TestCase):
         self.assertEqual(result, mock.sentinel.link)
 
 
-@mock.patch('spotify.artist.lib', spec=spotify.lib)
+@mock.patch("spotify.artist.lib", spec=spotify.lib)
 class ArtistBrowserTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
@@ -245,9 +245,9 @@ class ArtistBrowserTest(unittest.TestCase):
             spotify.ArtistBrowser(self.session)
 
     def test_create_from_artist(self, lib_mock):
-        sp_artist = spotify.ffi.cast('sp_artist *', 43)
+        sp_artist = spotify.ffi.cast("sp_artist *", 43)
         artist = spotify.Artist(self.session, sp_artist=sp_artist)
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         lib_mock.sp_artistbrowse_create.return_value = sp_artistbrowse
 
         result = artist.browse()
@@ -268,9 +268,9 @@ class ArtistBrowserTest(unittest.TestCase):
         self.assertTrue(result.loaded_event.is_set())
 
     def test_create_from_artist_with_type_and_callback(self, lib_mock):
-        sp_artist = spotify.ffi.cast('sp_artist *', 43)
+        sp_artist = spotify.ffi.cast("sp_artist *", 43)
         artist = spotify.Artist(self.session, sp_artist=sp_artist)
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         lib_mock.sp_artistbrowse_create.return_value = sp_artistbrowse
         callback = mock.Mock()
 
@@ -293,9 +293,9 @@ class ArtistBrowserTest(unittest.TestCase):
         callback.assert_called_with(result)
 
     def test_browser_is_gone_before_callback_is_called(self, lib_mock):
-        sp_artist = spotify.ffi.cast('sp_artist *', 43)
+        sp_artist = spotify.ffi.cast("sp_artist *", 43)
         artist = spotify.Artist(self.session, sp_artist=sp_artist)
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         lib_mock.sp_artistbrowse_create.return_value = sp_artistbrowse
         callback = mock.Mock()
 
@@ -315,14 +315,14 @@ class ArtistBrowserTest(unittest.TestCase):
         self.assertEqual(callback.call_args[0][0]._sp_artistbrowse, sp_artistbrowse)
 
     def test_adds_ref_to_sp_artistbrowse_when_created(self, lib_mock):
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
 
         spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         lib_mock.sp_artistbrowse_add_ref.assert_called_with(sp_artistbrowse)
 
     def test_releases_sp_artistbrowse_when_artist_dies(self, lib_mock):
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
 
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
         browser = None  # noqa
@@ -330,46 +330,46 @@ class ArtistBrowserTest(unittest.TestCase):
 
         lib_mock.sp_artistbrowse_release.assert_called_with(sp_artistbrowse)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_repr(self, link_mock, lib_mock):
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
         lib_mock.sp_artistbrowse_is_loaded.return_value = 1
-        sp_artist = spotify.ffi.cast('sp_artist *', 42)
+        sp_artist = spotify.ffi.cast("sp_artist *", 42)
         lib_mock.sp_artistbrowse_artist.return_value = sp_artist
         link_instance_mock = link_mock.return_value
-        link_instance_mock.uri = 'foo'
+        link_instance_mock.uri = "foo"
 
         result = repr(browser)
 
-        self.assertEqual(result, 'ArtistBrowser(%r)' % 'foo')
+        self.assertEqual(result, "ArtistBrowser(%r)" % "foo")
 
     def test_repr_if_unloaded(self, lib_mock):
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
         lib_mock.sp_artistbrowse_is_loaded.return_value = 0
 
         result = repr(browser)
 
-        self.assertEqual(result, 'ArtistBrowser(<not loaded>)')
+        self.assertEqual(result, "ArtistBrowser(<not loaded>)")
 
     def test_eq(self, lib_mock):
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser1 = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
         browser2 = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         self.assertTrue(browser1 == browser2)
-        self.assertFalse(browser1 == 'foo')
+        self.assertFalse(browser1 == "foo")
 
     def test_ne(self, lib_mock):
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser1 = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
         browser2 = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         self.assertFalse(browser1 != browser2)
 
     def test_hash(self, lib_mock):
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser1 = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
         browser2 = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
@@ -377,7 +377,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_is_loaded(self, lib_mock):
         lib_mock.sp_artistbrowse_is_loaded.return_value = 1
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.is_loaded
@@ -385,9 +385,9 @@ class ArtistBrowserTest(unittest.TestCase):
         lib_mock.sp_artistbrowse_is_loaded.assert_called_once_with(sp_artistbrowse)
         self.assertTrue(result)
 
-    @mock.patch('spotify.utils.load')
+    @mock.patch("spotify.utils.load")
     def test_load(self, load_mock, lib_mock):
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         browser.load(10)
@@ -398,7 +398,7 @@ class ArtistBrowserTest(unittest.TestCase):
         lib_mock.sp_artistbrowse_error.return_value = int(
             spotify.ErrorType.OTHER_PERMANENT
         )
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.error
@@ -408,7 +408,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_backend_request_duration(self, lib_mock):
         lib_mock.sp_artistbrowse_backend_request_duration.return_value = 137
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.backend_request_duration
@@ -420,7 +420,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_backend_request_duration_when_not_loaded(self, lib_mock):
         lib_mock.sp_artistbrowse_is_loaded.return_value = 0
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.backend_request_duration
@@ -432,9 +432,9 @@ class ArtistBrowserTest(unittest.TestCase):
         self.assertIsNone(result)
 
     def test_artist(self, lib_mock):
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
-        sp_artist = spotify.ffi.cast('sp_artist *', 43)
+        sp_artist = spotify.ffi.cast("sp_artist *", 43)
         lib_mock.sp_artistbrowse_artist.return_value = sp_artist
 
         result = browser.artist
@@ -443,7 +443,7 @@ class ArtistBrowserTest(unittest.TestCase):
         self.assertEqual(result._sp_artist, sp_artist)
 
     def test_artist_when_not_loaded(self, lib_mock):
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
         lib_mock.sp_artistbrowse_artist.return_value = spotify.ffi.NULL
 
@@ -452,14 +452,14 @@ class ArtistBrowserTest(unittest.TestCase):
         lib_mock.sp_artistbrowse_artist.assert_called_with(sp_artistbrowse)
         self.assertIsNone(result)
 
-    @mock.patch('spotify.Image', spec=spotify.Image)
+    @mock.patch("spotify.Image", spec=spotify.Image)
     def test_portraits(self, image_mock, lib_mock):
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
         lib_mock.sp_artistbrowse_num_portraits.return_value = 1
-        image_id = spotify.ffi.new('char[]', b'image-id')
+        image_id = spotify.ffi.new("char[]", b"image-id")
         lib_mock.sp_artistbrowse_portrait.return_value = image_id
-        sp_image = spotify.ffi.cast('sp_image *', 43)
+        sp_image = spotify.ffi.cast("sp_image *", 43)
         lib_mock.sp_image_create.return_value = sp_image
         image_mock.return_value = mock.sentinel.image
         callback = mock.Mock()
@@ -485,7 +485,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_portraits_if_no_portraits(self, lib_mock):
         lib_mock.sp_artistbrowse_num_portraits.return_value = 0
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.portraits()
@@ -496,7 +496,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_portraits_if_unloaded(self, lib_mock):
         lib_mock.sp_artistbrowse_is_loaded.return_value = 0
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.portraits()
@@ -504,12 +504,12 @@ class ArtistBrowserTest(unittest.TestCase):
         lib_mock.sp_artistbrowse_is_loaded.assert_called_with(sp_artistbrowse)
         self.assertEqual(len(result), 0)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_tracks(self, track_lib_mock, lib_mock):
-        sp_track = spotify.ffi.cast('sp_track *', 43)
+        sp_track = spotify.ffi.cast("sp_track *", 43)
         lib_mock.sp_artistbrowse_num_tracks.return_value = 1
         lib_mock.sp_artistbrowse_track.return_value = sp_track
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         self.assertEqual(lib_mock.sp_artistbrowse_add_ref.call_count, 1)
@@ -528,7 +528,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_tracks_if_no_tracks(self, lib_mock):
         lib_mock.sp_artistbrowse_num_tracks.return_value = 0
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.tracks
@@ -539,7 +539,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_tracks_if_unloaded(self, lib_mock):
         lib_mock.sp_artistbrowse_is_loaded.return_value = 0
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.tracks
@@ -547,12 +547,12 @@ class ArtistBrowserTest(unittest.TestCase):
         lib_mock.sp_artistbrowse_is_loaded.assert_called_with(sp_artistbrowse)
         self.assertEqual(len(result), 0)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_tophit_tracks(self, track_lib_mock, lib_mock):
-        sp_track = spotify.ffi.cast('sp_track *', 43)
+        sp_track = spotify.ffi.cast("sp_track *", 43)
         lib_mock.sp_artistbrowse_num_tophit_tracks.return_value = 1
         lib_mock.sp_artistbrowse_tophit_track.return_value = sp_track
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         self.assertEqual(lib_mock.sp_artistbrowse_add_ref.call_count, 1)
@@ -571,7 +571,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_tophit_tracks_if_no_tracks(self, lib_mock):
         lib_mock.sp_artistbrowse_num_tophit_tracks.return_value = 0
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.tophit_tracks
@@ -582,7 +582,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_tophit_tracks_if_unloaded(self, lib_mock):
         lib_mock.sp_artistbrowse_is_loaded.return_value = 0
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.tophit_tracks
@@ -590,12 +590,12 @@ class ArtistBrowserTest(unittest.TestCase):
         lib_mock.sp_artistbrowse_is_loaded.assert_called_with(sp_artistbrowse)
         self.assertEqual(len(result), 0)
 
-    @mock.patch('spotify.album.lib', spec=spotify.lib)
+    @mock.patch("spotify.album.lib", spec=spotify.lib)
     def test_albums(self, album_lib_mock, lib_mock):
-        sp_album = spotify.ffi.cast('sp_album *', 43)
+        sp_album = spotify.ffi.cast("sp_album *", 43)
         lib_mock.sp_artistbrowse_num_albums.return_value = 1
         lib_mock.sp_artistbrowse_album.return_value = sp_album
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         self.assertEqual(lib_mock.sp_artistbrowse_add_ref.call_count, 1)
@@ -614,7 +614,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_albums_if_no_albums(self, lib_mock):
         lib_mock.sp_artistbrowse_num_albums.return_value = 0
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.albums
@@ -625,7 +625,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_albums_if_unloaded(self, lib_mock):
         lib_mock.sp_artistbrowse_is_loaded.return_value = 0
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.albums
@@ -634,10 +634,10 @@ class ArtistBrowserTest(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
     def test_similar_artists(self, lib_mock):
-        sp_artist = spotify.ffi.cast('sp_artist *', 43)
+        sp_artist = spotify.ffi.cast("sp_artist *", 43)
         lib_mock.sp_artistbrowse_num_similar_artists.return_value = 1
         lib_mock.sp_artistbrowse_similar_artist.return_value = sp_artist
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         self.assertEqual(lib_mock.sp_artistbrowse_add_ref.call_count, 1)
@@ -656,7 +656,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_similar_artists_if_no_artists(self, lib_mock):
         lib_mock.sp_artistbrowse_num_similar_artists.return_value = 0
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.similar_artists
@@ -667,7 +667,7 @@ class ArtistBrowserTest(unittest.TestCase):
 
     def test_similar_artists_if_unloaded(self, lib_mock):
         lib_mock.sp_artistbrowse_is_loaded.return_value = 0
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
 
         result = browser.similar_artists
@@ -676,15 +676,15 @@ class ArtistBrowserTest(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
     def test_biography(self, lib_mock):
-        sp_artistbrowse = spotify.ffi.cast('sp_artistbrowse *', 42)
+        sp_artistbrowse = spotify.ffi.cast("sp_artistbrowse *", 42)
         browser = spotify.ArtistBrowser(self.session, sp_artistbrowse=sp_artistbrowse)
-        biography = spotify.ffi.new('char[]', b'Lived, played, and died')
+        biography = spotify.ffi.new("char[]", b"Lived, played, and died")
         lib_mock.sp_artistbrowse_biography.return_value = biography
 
         result = browser.biography
 
         self.assertIsInstance(result, compat.text_type)
-        self.assertEqual(result, 'Lived, played, and died')
+        self.assertEqual(result, "Lived, played, and died")
 
 
 class ArtistBrowserTypeTest(unittest.TestCase):

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -3,9 +3,8 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-from spotify import compat
-
 import tests
+from spotify import compat
 from tests import mock
 
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -19,7 +19,7 @@ class AudioBufferStatsTest(unittest.TestCase):
 
 class AudioFormatTest(unittest.TestCase):
     def setUp(self):
-        self._sp_audioformat = spotify.ffi.new('sp_audioformat *')
+        self._sp_audioformat = spotify.ffi.new("sp_audioformat *")
         self._sp_audioformat.sample_type = spotify.SampleType.INT16_NATIVE_ENDIAN
         self._sp_audioformat.sample_rate = 44100
         self._sp_audioformat.channels = 2

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -20,9 +20,7 @@ class AudioBufferStatsTest(unittest.TestCase):
 class AudioFormatTest(unittest.TestCase):
     def setUp(self):
         self._sp_audioformat = spotify.ffi.new('sp_audioformat *')
-        self._sp_audioformat.sample_type = (
-            spotify.SampleType.INT16_NATIVE_ENDIAN
-        )
+        self._sp_audioformat.sample_type = spotify.SampleType.INT16_NATIVE_ENDIAN
         self._sp_audioformat.sample_rate = 44100
         self._sp_audioformat.channels = 2
         self.audio_format = spotify.AudioFormat(self._sp_audioformat)
@@ -41,9 +39,7 @@ class AudioFormatTest(unittest.TestCase):
 
     def test_frame_size(self):
         # INT16 means 16 bits aka 2 bytes per channel
-        self._sp_audioformat.sample_type = (
-            spotify.SampleType.INT16_NATIVE_ENDIAN
-        )
+        self._sp_audioformat.sample_type = spotify.SampleType.INT16_NATIVE_ENDIAN
 
         self._sp_audioformat.channels = 1
         self.assertEqual(self.audio_format.frame_size(), 2)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,9 +21,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(self.config.api_version, 71)
 
     def test_api_version_defaults_to_current_lib_version(self):
-        self.assertEqual(
-            self.config.api_version, spotify.lib.SPOTIFY_API_VERSION
-        )
+        self.assertEqual(self.config.api_version, spotify.lib.SPOTIFY_API_VERSION)
 
     def test_cache_location(self):
         self.config.cache_location = b'/cache'
@@ -50,9 +48,7 @@ class ConfigTest(unittest.TestCase):
         self.config.settings_location = b'/settings'
 
         self.assertEqual(
-            spotify.ffi.string(
-                self.config._sp_session_config.settings_location
-            ),
+            spotify.ffi.string(self.config._sp_session_config.settings_location),
             b'/settings',
         )
         self.assertEqual(self.config.settings_location, b'/settings')
@@ -64,9 +60,7 @@ class ConfigTest(unittest.TestCase):
         self.config.settings_location = None
 
         self.assertEqual(
-            spotify.ffi.string(
-                self.config._sp_session_config.settings_location
-            ),
+            spotify.ffi.string(self.config._sp_session_config.settings_location),
             b'',
         )
         self.assertEqual(self.config.settings_location, b'')
@@ -93,9 +87,7 @@ class ConfigTest(unittest.TestCase):
     def test_application_key_size_is_calculated_correctly(self):
         self.config.application_key = b'\x01' * 321
 
-        self.assertEqual(
-            self.config._sp_session_config.application_key_size, 321
-        )
+        self.assertEqual(self.config._sp_session_config.application_key_size, 321)
 
     def test_application_key_can_be_reset_to_none(self):
         self.config.application_key = None
@@ -139,9 +131,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(self.config.user_agent, 'an agent')
 
     def test_user_agent_defaults_to_pyspotify_with_version_number(self):
-        self.assertEqual(
-            self.config.user_agent, 'pyspotify %s' % spotify.__version__
-        )
+        self.assertEqual(self.config.user_agent, 'pyspotify %s' % spotify.__version__)
 
     def test_user_agent_location_converts_none_to_empty_string(self):
         self.config.user_agent = None
@@ -174,9 +164,7 @@ class ConfigTest(unittest.TestCase):
     def test_initially_unload_playlists(self):
         self.config.initially_unload_playlists = True
 
-        self.assertEqual(
-            self.config._sp_session_config.initially_unload_playlists, 1
-        )
+        self.assertEqual(self.config._sp_session_config.initially_unload_playlists, 1)
         self.assertEqual(self.config.initially_unload_playlists, True)
 
     def test_initially_unload_playlists_defaults_to_false(self):
@@ -197,9 +185,7 @@ class ConfigTest(unittest.TestCase):
     def test_device_id_converts_empty_string_to_none(self):
         self.config.device_id = ''
 
-        self.assertEqual(
-            self.config._sp_session_config.device_id, spotify.ffi.NULL
-        )
+        self.assertEqual(self.config._sp_session_config.device_id, spotify.ffi.NULL)
         self.assertIsNone(self.config.device_id)
 
     def test_proxy(self):
@@ -216,9 +202,7 @@ class ConfigTest(unittest.TestCase):
     def test_proxy_converts_none_to_empty_string_and_back(self):
         self.config.proxy = None
 
-        self.assertEqual(
-            spotify.ffi.string(self.config._sp_session_config.proxy), b''
-        )
+        self.assertEqual(spotify.ffi.string(self.config._sp_session_config.proxy), b'')
         self.assertIsNone(self.config.proxy)
 
     def test_proxy_username(self):
@@ -308,9 +292,7 @@ class ConfigTest(unittest.TestCase):
     def test_tracefile_converts_empty_string_to_none(self):
         self.config.tracefile = ''
 
-        self.assertEqual(
-            self.config._sp_session_config.tracefile, spotify.ffi.NULL
-        )
+        self.assertEqual(self.config._sp_session_config.tracefile, spotify.ffi.NULL)
         self.assertIsNone(self.config.tracefile)
 
     def test_sp_session_config_has_unicode_encoded_as_utf8(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,59 +24,59 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(self.config.api_version, spotify.lib.SPOTIFY_API_VERSION)
 
     def test_cache_location(self):
-        self.config.cache_location = b'/cache'
+        self.config.cache_location = b"/cache"
 
         self.assertEqual(
             spotify.ffi.string(self.config._sp_session_config.cache_location),
-            b'/cache',
+            b"/cache",
         )
-        self.assertEqual(self.config.cache_location, b'/cache')
+        self.assertEqual(self.config.cache_location, b"/cache")
 
     def test_cache_location_defaults_to_tmp_in_cwd(self):
-        self.assertEqual(self.config.cache_location, b'tmp')
+        self.assertEqual(self.config.cache_location, b"tmp")
 
     def test_cache_location_converts_none_to_empty_string(self):
         self.config.cache_location = None
 
         self.assertEqual(
             spotify.ffi.string(self.config._sp_session_config.cache_location),
-            b'',
+            b"",
         )
-        self.assertEqual(self.config.cache_location, b'')
+        self.assertEqual(self.config.cache_location, b"")
 
     def test_settings_location(self):
-        self.config.settings_location = b'/settings'
+        self.config.settings_location = b"/settings"
 
         self.assertEqual(
             spotify.ffi.string(self.config._sp_session_config.settings_location),
-            b'/settings',
+            b"/settings",
         )
-        self.assertEqual(self.config.settings_location, b'/settings')
+        self.assertEqual(self.config.settings_location, b"/settings")
 
     def test_settings_location_defaults_to_tmp_in_cwd(self):
-        self.assertEqual(self.config.settings_location, b'tmp')
+        self.assertEqual(self.config.settings_location, b"tmp")
 
     def test_settings_location_converts_none_to_empty_string(self):
         self.config.settings_location = None
 
         self.assertEqual(
             spotify.ffi.string(self.config._sp_session_config.settings_location),
-            b'',
+            b"",
         )
-        self.assertEqual(self.config.settings_location, b'')
+        self.assertEqual(self.config.settings_location, b"")
 
     def test_application_key(self):
-        self.config.application_key = b'\x02' * 321
+        self.config.application_key = b"\x02" * 321
 
         self.assertEqual(
             spotify.ffi.string(
                 spotify.ffi.cast(
-                    'char *', self.config._sp_session_config.application_key
+                    "char *", self.config._sp_session_config.application_key
                 )
             ),
-            b'\x02' * 321,
+            b"\x02" * 321,
         )
-        self.assertEqual(self.config.application_key, b'\x02' * 321)
+        self.assertEqual(self.config.application_key, b"\x02" * 321)
 
     def test_application_key_is_unknown(self):
         self.assertIsNone(self.config.application_key)
@@ -85,7 +85,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(self.config._sp_session_config.application_key_size, 0)
 
     def test_application_key_size_is_calculated_correctly(self):
-        self.config.application_key = b'\x01' * 321
+        self.config.application_key = b"\x01" * 321
 
         self.assertEqual(self.config._sp_session_config.application_key_size, 321)
 
@@ -97,49 +97,49 @@ class ConfigTest(unittest.TestCase):
 
     def test_application_key_fails_if_invalid_key(self):
         with self.assertRaises(AssertionError):
-            self.config.application_key = 'way too short key'
+            self.config.application_key = "way too short key"
 
     def test_load_application_key_file_can_load_key_from_file(self):
         self.config.application_key = None
         filename = tempfile.mkstemp()[1]
-        with open(filename, 'wb') as f:
-            f.write(b'\x03' * 321)
+        with open(filename, "wb") as f:
+            f.write(b"\x03" * 321)
 
         self.config.load_application_key_file(filename)
 
-        self.assertEqual(self.config.application_key, b'\x03' * 321)
+        self.assertEqual(self.config.application_key, b"\x03" * 321)
 
     def test_load_application_key_file_defaults_to_a_file_in_cwd(self):
-        open_mock = mock.mock_open(read_data='\x04' * 321)
-        with mock.patch('spotify.config.open', open_mock, create=True) as m:
+        open_mock = mock.mock_open(read_data="\x04" * 321)
+        with mock.patch("spotify.config.open", open_mock, create=True) as m:
             self.config.load_application_key_file()
 
-        m.assert_called_once_with(b'spotify_appkey.key', 'rb')
-        self.assertEqual(self.config.application_key, b'\x04' * 321)
+        m.assert_called_once_with(b"spotify_appkey.key", "rb")
+        self.assertEqual(self.config.application_key, b"\x04" * 321)
 
     def test_load_application_key_file_fails_if_no_key_found(self):
         with self.assertRaises(EnvironmentError):
-            self.config.load_application_key_file(b'/nonexistant')
+            self.config.load_application_key_file(b"/nonexistant")
 
     def test_user_agent(self):
-        self.config.user_agent = 'an agent'
+        self.config.user_agent = "an agent"
 
         self.assertEqual(
             spotify.ffi.string(self.config._sp_session_config.user_agent),
-            b'an agent',
+            b"an agent",
         )
-        self.assertEqual(self.config.user_agent, 'an agent')
+        self.assertEqual(self.config.user_agent, "an agent")
 
     def test_user_agent_defaults_to_pyspotify_with_version_number(self):
-        self.assertEqual(self.config.user_agent, 'pyspotify %s' % spotify.__version__)
+        self.assertEqual(self.config.user_agent, "pyspotify %s" % spotify.__version__)
 
     def test_user_agent_location_converts_none_to_empty_string(self):
         self.config.user_agent = None
 
         self.assertEqual(
-            spotify.ffi.string(self.config._sp_session_config.user_agent), b''
+            spotify.ffi.string(self.config._sp_session_config.user_agent), b""
         )
-        self.assertEqual(self.config.user_agent, '')
+        self.assertEqual(self.config.user_agent, "")
 
     def test_compress_playlists(self):
         self.config.compress_playlists = True
@@ -171,30 +171,30 @@ class ConfigTest(unittest.TestCase):
         self.assertFalse(self.config.initially_unload_playlists)
 
     def test_device_id(self):
-        self.config.device_id = '123abc'
+        self.config.device_id = "123abc"
 
         self.assertEqual(
             spotify.ffi.string(self.config._sp_session_config.device_id),
-            b'123abc',
+            b"123abc",
         )
-        self.assertEqual(self.config.device_id, '123abc')
+        self.assertEqual(self.config.device_id, "123abc")
 
     def test_device_id_defaults_to_none(self):
         self.assertIsNone(self.config.device_id)
 
     def test_device_id_converts_empty_string_to_none(self):
-        self.config.device_id = ''
+        self.config.device_id = ""
 
         self.assertEqual(self.config._sp_session_config.device_id, spotify.ffi.NULL)
         self.assertIsNone(self.config.device_id)
 
     def test_proxy(self):
-        self.config.proxy = '123abc'
+        self.config.proxy = "123abc"
 
         self.assertEqual(
-            spotify.ffi.string(self.config._sp_session_config.proxy), b'123abc'
+            spotify.ffi.string(self.config._sp_session_config.proxy), b"123abc"
         )
-        self.assertEqual(self.config.proxy, '123abc')
+        self.assertEqual(self.config.proxy, "123abc")
 
     def test_proxy_defaults_to_none(self):
         self.assertIsNone(self.config.proxy)
@@ -202,17 +202,17 @@ class ConfigTest(unittest.TestCase):
     def test_proxy_converts_none_to_empty_string_and_back(self):
         self.config.proxy = None
 
-        self.assertEqual(spotify.ffi.string(self.config._sp_session_config.proxy), b'')
+        self.assertEqual(spotify.ffi.string(self.config._sp_session_config.proxy), b"")
         self.assertIsNone(self.config.proxy)
 
     def test_proxy_username(self):
-        self.config.proxy_username = '123abc'
+        self.config.proxy_username = "123abc"
 
         self.assertEqual(
             spotify.ffi.string(self.config._sp_session_config.proxy_username),
-            b'123abc',
+            b"123abc",
         )
-        self.assertEqual(self.config.proxy_username, '123abc')
+        self.assertEqual(self.config.proxy_username, "123abc")
 
     def test_proxy_username_defaults_to_none(self):
         self.assertIsNone(self.config.proxy_username)
@@ -222,18 +222,18 @@ class ConfigTest(unittest.TestCase):
 
         self.assertEqual(
             spotify.ffi.string(self.config._sp_session_config.proxy_username),
-            b'',
+            b"",
         )
         self.assertIsNone(self.config.proxy_username)
 
     def test_proxy_password(self):
-        self.config.proxy_password = '123abc'
+        self.config.proxy_password = "123abc"
 
         self.assertEqual(
             spotify.ffi.string(self.config._sp_session_config.proxy_password),
-            b'123abc',
+            b"123abc",
         )
-        self.assertEqual(self.config.proxy_password, '123abc')
+        self.assertEqual(self.config.proxy_password, "123abc")
 
     def test_proxy_password_defaults_to_none(self):
         self.assertIsNone(self.config.proxy_password)
@@ -243,97 +243,97 @@ class ConfigTest(unittest.TestCase):
 
         self.assertEqual(
             spotify.ffi.string(self.config._sp_session_config.proxy_password),
-            b'',
+            b"",
         )
         self.assertIsNone(self.config.proxy_password)
 
     @unittest.skipIf(
-        platform.system() == 'Darwin',
-        'The struct field does not exist in libspotify for OS X',
+        platform.system() == "Darwin",
+        "The struct field does not exist in libspotify for OS X",
     )
     def test_ca_certs_filename(self):
-        self.config.ca_certs_filename = b'ca.crt'
+        self.config.ca_certs_filename = b"ca.crt"
 
         self.assertEqual(
             spotify.ffi.string(self.config._get_ca_certs_filename_ptr()[0]),
-            b'ca.crt',
+            b"ca.crt",
         )
-        self.assertEqual(self.config.ca_certs_filename, b'ca.crt')
+        self.assertEqual(self.config.ca_certs_filename, b"ca.crt")
 
     @unittest.skipIf(
-        platform.system() == 'Darwin',
-        'The struct field does not exist in libspotify for OS X',
+        platform.system() == "Darwin",
+        "The struct field does not exist in libspotify for OS X",
     )
     def test_ca_certs_filename_defaults_to_none(self):
         self.assertIsNone(self.config.ca_certs_filename)
 
     @unittest.skipIf(
-        platform.system() != 'Darwin', 'Not supported on this operating system'
+        platform.system() != "Darwin", "Not supported on this operating system"
     )
     def test_ca_certs_filename_is_a_noop_on_os_x(self):
         self.assertIsNone(self.config.ca_certs_filename)
 
-        self.config.ca_certs_filename = b'ca.crt'
+        self.config.ca_certs_filename = b"ca.crt"
 
         self.assertIsNone(self.config.ca_certs_filename)
 
     def test_tracefile(self):
-        self.config.tracefile = b'123abc'
+        self.config.tracefile = b"123abc"
 
         self.assertEqual(
             spotify.ffi.string(self.config._sp_session_config.tracefile),
-            b'123abc',
+            b"123abc",
         )
-        self.assertEqual(self.config.tracefile, b'123abc')
+        self.assertEqual(self.config.tracefile, b"123abc")
 
     def test_tracefile_defaults_to_none(self):
         self.assertIsNone(self.config.tracefile)
 
     def test_tracefile_converts_empty_string_to_none(self):
-        self.config.tracefile = ''
+        self.config.tracefile = ""
 
         self.assertEqual(self.config._sp_session_config.tracefile, spotify.ffi.NULL)
         self.assertIsNone(self.config.tracefile)
 
     def test_sp_session_config_has_unicode_encoded_as_utf8(self):
-        self.config.device_id = 'æ device_id'
-        self.config.proxy = 'æ proxy'
-        self.config.proxy_username = 'æ proxy_username'
-        self.config.proxy_password = 'æ proxy_password'
-        self.config.tracefile = 'æ tracefile'.encode('utf-8')
+        self.config.device_id = "æ device_id"
+        self.config.proxy = "æ proxy"
+        self.config.proxy_username = "æ proxy_username"
+        self.config.proxy_password = "æ proxy_password"
+        self.config.tracefile = "æ tracefile".encode("utf-8")
 
         self.assertEqual(
             spotify.ffi.string(self.config._sp_session_config.device_id),
-            b'\xc3\xa6 device_id',
+            b"\xc3\xa6 device_id",
         )
         self.assertEqual(
             spotify.ffi.string(self.config._sp_session_config.proxy),
-            b'\xc3\xa6 proxy',
+            b"\xc3\xa6 proxy",
         )
         self.assertEqual(
             spotify.ffi.string(self.config._sp_session_config.proxy_username),
-            b'\xc3\xa6 proxy_username',
+            b"\xc3\xa6 proxy_username",
         )
         self.assertEqual(
             spotify.ffi.string(self.config._sp_session_config.proxy_password),
-            b'\xc3\xa6 proxy_password',
+            b"\xc3\xa6 proxy_password",
         )
         self.assertEqual(
             spotify.ffi.string(self.config._sp_session_config.tracefile),
-            b'\xc3\xa6 tracefile',
+            b"\xc3\xa6 tracefile",
         )
 
     @unittest.skipIf(
-        platform.system() == 'Darwin',
-        'The struct field does not exist in libspotify for OS X',
+        platform.system() == "Darwin",
+        "The struct field does not exist in libspotify for OS X",
     )
     def test_sp_session_config_ca_certs_filename_has_unicode_encoded_as_utf8(
         self,
     ):
 
-        self.config.ca_certs_filename = 'æ ca_certs_filename'
+        self.config.ca_certs_filename = "æ ca_certs_filename"
 
         self.assertEqual(
             spotify.ffi.string(self.config._get_ca_certs_filename_ptr()[0]),
-            b'\xc3\xa6 ca_certs_filename',
+            b"\xc3\xa6 ca_certs_filename",
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,6 @@ import tempfile
 import unittest
 
 import spotify
-
 from tests import mock
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -7,8 +7,8 @@ import tests
 from tests import mock
 
 
-@mock.patch('spotify.connection.lib', spec=spotify.lib)
-@mock.patch('spotify.session.lib', spec=spotify.lib)
+@mock.patch("spotify.connection.lib", spec=spotify.lib)
+@mock.patch("spotify.session.lib", spec=spotify.lib)
 class ConnectionTest(unittest.TestCase):
     def tearDown(self):
         spotify._session_instance = None

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-
 import tests
 from tests import mock
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -19,20 +19,12 @@ class ConnectionTest(unittest.TestCase):
         )
         session = tests.create_real_session(session_lib_mock)
 
-        self.assertIs(
-            session.connection.state, spotify.ConnectionState.LOGGED_OUT
-        )
+        self.assertIs(session.connection.state, spotify.ConnectionState.LOGGED_OUT)
 
-        lib_mock.sp_session_connectionstate.assert_called_once_with(
-            session._sp_session
-        )
+        lib_mock.sp_session_connectionstate.assert_called_once_with(session._sp_session)
 
-    def test_connection_type_defaults_to_unknown(
-        self, session_lib_mock, lib_mock
-    ):
-        lib_mock.sp_session_set_connection_type.return_value = (
-            spotify.ErrorType.OK
-        )
+    def test_connection_type_defaults_to_unknown(self, session_lib_mock, lib_mock):
+        lib_mock.sp_session_set_connection_type.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(session_lib_mock)
 
         result = session.connection.type
@@ -41,9 +33,7 @@ class ConnectionTest(unittest.TestCase):
         self.assertEqual(lib_mock.sp_session_set_connection_type.call_count, 0)
 
     def test_set_connection_type(self, session_lib_mock, lib_mock):
-        lib_mock.sp_session_set_connection_type.return_value = (
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_session_set_connection_type.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(session_lib_mock)
 
         session.connection.type = spotify.ConnectionType.MOBILE_ROAMING
@@ -56,9 +46,7 @@ class ConnectionTest(unittest.TestCase):
 
         self.assertIs(result, spotify.ConnectionType.MOBILE_ROAMING)
 
-    def test_set_connection_type_fail_raises_error(
-        self, session_lib_mock, lib_mock
-    ):
+    def test_set_connection_type_fail_raises_error(self, session_lib_mock, lib_mock):
         lib_mock.sp_session_set_connection_type.return_value = (
             spotify.ErrorType.BAD_API_VERSION
         )
@@ -77,9 +65,7 @@ class ConnectionTest(unittest.TestCase):
         self.assertTrue(session.connection.allow_network)
 
     def test_set_allow_network(self, session_lib_mock, lib_mock):
-        lib_mock.sp_session_set_connection_rules.return_value = (
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_session_set_connection_rules.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(session_lib_mock)
 
         session.connection.allow_network = False
@@ -98,9 +84,7 @@ class ConnectionTest(unittest.TestCase):
         self.assertFalse(session.connection.allow_network_if_roaming)
 
     def test_set_allow_network_if_roaming(self, session_lib_mock, lib_mock):
-        lib_mock.sp_session_set_connection_rules.return_value = (
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_session_set_connection_rules.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(session_lib_mock)
 
         session.connection.allow_network_if_roaming = True
@@ -113,17 +97,13 @@ class ConnectionTest(unittest.TestCase):
             | spotify.ConnectionRule.ALLOW_SYNC_OVER_WIFI,
         )
 
-    def test_allow_sync_over_wifi_defaults_to_true(
-        self, session_lib_mock, lib_mock
-    ):
+    def test_allow_sync_over_wifi_defaults_to_true(self, session_lib_mock, lib_mock):
         session = tests.create_real_session(session_lib_mock)
 
         self.assertTrue(session.connection.allow_sync_over_wifi)
 
     def test_set_allow_sync_over_wifi(self, session_lib_mock, lib_mock):
-        lib_mock.sp_session_set_connection_rules.return_value = (
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_session_set_connection_rules.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(session_lib_mock)
 
         session.connection.allow_sync_over_wifi = False
@@ -133,17 +113,13 @@ class ConnectionTest(unittest.TestCase):
             session._sp_session, int(spotify.ConnectionRule.NETWORK)
         )
 
-    def test_allow_sync_over_mobile_defaults_to_false(
-        self, session_lib_mock, lib_mock
-    ):
+    def test_allow_sync_over_mobile_defaults_to_false(self, session_lib_mock, lib_mock):
         session = tests.create_real_session(session_lib_mock)
 
         self.assertFalse(session.connection.allow_sync_over_mobile)
 
     def test_set_allow_sync_over_mobile(self, session_lib_mock, lib_mock):
-        lib_mock.sp_session_set_connection_rules.return_value = (
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_session_set_connection_rules.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(session_lib_mock)
 
         session.connection.allow_sync_over_mobile = True
@@ -156,12 +132,8 @@ class ConnectionTest(unittest.TestCase):
             | spotify.ConnectionRule.ALLOW_SYNC_OVER_MOBILE,
         )
 
-    def test_set_connection_rules_without_rules(
-        self, session_lib_mock, lib_mock
-    ):
-        lib_mock.sp_session_set_connection_rules.return_value = (
-            spotify.ErrorType.OK
-        )
+    def test_set_connection_rules_without_rules(self, session_lib_mock, lib_mock):
+        lib_mock.sp_session_set_connection_rules.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(session_lib_mock)
 
         session.connection.allow_network = False
@@ -171,9 +143,7 @@ class ConnectionTest(unittest.TestCase):
             session._sp_session, 0
         )
 
-    def test_set_connection_rules_fail_raises_error(
-        self, session_lib_mock, lib_mock
-    ):
+    def test_set_connection_rules_fail_raises_error(self, session_lib_mock, lib_mock):
         lib_mock.sp_session_set_connection_rules.return_value = (
             spotify.ErrorType.BAD_API_VERSION
         )

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -51,15 +51,15 @@ class LibErrorTest(unittest.TestCase):
 
     def test_error_has_useful_repr(self):
         error = spotify.LibError(0)
-        self.assertIn('No error', repr(error))
+        self.assertIn("No error", repr(error))
 
     def test_error_has_useful_string_representation(self):
         error = spotify.LibError(0)
-        self.assertEqual('%s' % error, 'No error')
-        self.assertIsInstance('%s' % error, compat.text_type)
+        self.assertEqual("%s" % error, "No error")
+        self.assertIsInstance("%s" % error, compat.text_type)
 
         error = spotify.LibError(1)
-        self.assertEqual('%s' % error, 'Invalid library version')
+        self.assertEqual("%s" % error, "Invalid library version")
 
     def test_has_error_constants(self):
         self.assertEqual(spotify.LibError.OK, spotify.LibError(spotify.ErrorType.OK))
@@ -82,9 +82,9 @@ class TimeoutTest(unittest.TestCase):
 
     def test_has_useful_repr(self):
         error = spotify.Timeout(0.5)
-        self.assertIn('Operation did not complete in 0.500s', repr(error))
+        self.assertIn("Operation did not complete in 0.500s", repr(error))
 
     def test_has_useful_string_representation(self):
         error = spotify.Timeout(0.5)
-        self.assertEqual('%s' % error, 'Operation did not complete in 0.500s')
-        self.assertIsInstance('%s' % error, compat.text_type)
+        self.assertEqual("%s" % error, "Operation did not complete in 0.500s")
+        self.assertIsInstance("%s" % error, compat.text_type)

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -62,9 +62,7 @@ class LibErrorTest(unittest.TestCase):
         self.assertEqual('%s' % error, 'Invalid library version')
 
     def test_has_error_constants(self):
-        self.assertEqual(
-            spotify.LibError.OK, spotify.LibError(spotify.ErrorType.OK)
-        )
+        self.assertEqual(spotify.LibError.OK, spotify.LibError(spotify.ErrorType.OK))
         self.assertEqual(
             spotify.LibError.BAD_API_VERSION,
             spotify.LibError(spotify.ErrorType.BAD_API_VERSION),

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -30,7 +30,7 @@ class EventLoopTest(unittest.TestCase):
         self.assertTrue(self.loop.daemon)
 
     def test_has_a_descriptive_thread_name(self):
-        self.assertEqual(self.loop.name, 'SpotifyEventLoop')
+        self.assertEqual(self.loop.name, "SpotifyEventLoop")
 
     def test_can_be_started_and_stopped_and_joined(self):
         self.assertFalse(self.loop.is_alive())

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -11,7 +11,6 @@ except ImportError:
     import Queue as queue
 
 import spotify
-
 from tests import mock
 
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -22,9 +22,7 @@ class ImageTest(unittest.TestCase):
 
     @mock.patch('spotify.Link', spec=spotify.Link)
     def test_create_from_uri(self, link_mock, lib_mock):
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         link_instance_mock = link_mock.return_value
         link_instance_mock.as_image.return_value = spotify.Image(
@@ -50,9 +48,7 @@ class ImageTest(unittest.TestCase):
             spotify.Image(self.session, uri=uri)
 
     def test_adds_ref_to_sp_image_when_created(self, lib_mock):
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
 
         spotify.Image(self.session, sp_image=sp_image)
@@ -60,9 +56,7 @@ class ImageTest(unittest.TestCase):
         lib_mock.sp_image_add_ref.assert_called_with(sp_image)
 
     def test_releases_sp_image_when_image_dies(self, lib_mock):
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
 
         image = spotify.Image(self.session, sp_image=sp_image)
@@ -75,9 +69,7 @@ class ImageTest(unittest.TestCase):
     def test_repr(self, link_mock, lib_mock):
         link_instance_mock = link_mock.return_value
         link_instance_mock.uri = 'foo'
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
@@ -86,9 +78,7 @@ class ImageTest(unittest.TestCase):
         self.assertEqual(result, 'Image(%r)' % 'foo')
 
     def test_eq(self, lib_mock):
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         image1 = spotify.Image(self.session, sp_image=sp_image)
         image2 = spotify.Image(self.session, sp_image=sp_image)
@@ -97,9 +87,7 @@ class ImageTest(unittest.TestCase):
         self.assertFalse(image1 == 'foo')
 
     def test_ne(self, lib_mock):
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         image1 = spotify.Image(self.session, sp_image=sp_image)
         image2 = spotify.Image(self.session, sp_image=sp_image)
@@ -107,9 +95,7 @@ class ImageTest(unittest.TestCase):
         self.assertFalse(image1 != image2)
 
     def test_hash(self, lib_mock):
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         image1 = spotify.Image(self.session, sp_image=sp_image)
         image2 = spotify.Image(self.session, sp_image=sp_image)
@@ -117,29 +103,21 @@ class ImageTest(unittest.TestCase):
         self.assertEqual(hash(image1), hash(image2))
 
     def test_loaded_event_is_unset_by_default(self, lib_mock):
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
         self.assertFalse(image.loaded_event.is_set())
 
     def test_create_with_callback(self, lib_mock):
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
-        lib_mock.sp_image_remove_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
+        lib_mock.sp_image_remove_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         lib_mock.sp_image_create.return_value = sp_image
         callback = mock.Mock()
 
         # Add callback
-        image = spotify.Image(
-            self.session, sp_image=sp_image, callback=callback
-        )
+        image = spotify.Image(self.session, sp_image=sp_image, callback=callback)
 
         lib_mock.sp_image_add_load_callback.assert_called_with(
             sp_image, mock.ANY, mock.ANY
@@ -162,20 +140,14 @@ class ImageTest(unittest.TestCase):
         self, lib_mock
     ):
 
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
-        lib_mock.sp_image_remove_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
+        lib_mock.sp_image_remove_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         lib_mock.sp_image_create.return_value = sp_image
         callback = mock.Mock()
 
         # Add callback
-        image = spotify.Image(
-            self.session, sp_image=sp_image, callback=callback
-        )
+        image = spotify.Image(self.session, sp_image=sp_image, callback=callback)
         loaded_event = image.loaded_event
 
         # Throw away reference to 'image'
@@ -194,9 +166,7 @@ class ImageTest(unittest.TestCase):
         self.assertEqual(callback.call_count, 1)
         self.assertEqual(callback.call_args[0][0]._sp_image, sp_image)
 
-    def test_create_with_callback_fails_if_error_adding_callback(
-        self, lib_mock
-    ):
+    def test_create_with_callback_fails_if_error_adding_callback(self, lib_mock):
 
         lib_mock.sp_image_add_load_callback.return_value = int(
             spotify.ErrorType.BAD_API_VERSION
@@ -209,9 +179,7 @@ class ImageTest(unittest.TestCase):
 
     def test_is_loaded(self, lib_mock):
         lib_mock.sp_image_is_loaded.return_value = 1
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
@@ -222,9 +190,7 @@ class ImageTest(unittest.TestCase):
 
     def test_error(self, lib_mock):
         lib_mock.sp_image_error.return_value = int(spotify.ErrorType.IS_LOADING)
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
@@ -235,9 +201,7 @@ class ImageTest(unittest.TestCase):
 
     @mock.patch('spotify.utils.load')
     def test_load(self, load_mock, lib_mock):
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
@@ -248,9 +212,7 @@ class ImageTest(unittest.TestCase):
     def test_format(self, lib_mock):
         lib_mock.sp_image_is_loaded.return_value = 1
         lib_mock.sp_image_format.return_value = int(spotify.ImageFormat.JPEG)
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
@@ -261,9 +223,7 @@ class ImageTest(unittest.TestCase):
 
     def test_format_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_image_is_loaded.return_value = 0
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
@@ -284,9 +244,7 @@ class ImageTest(unittest.TestCase):
             return spotify.ffi.cast('void *', data)
 
         lib_mock.sp_image_data.side_effect = func
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
@@ -297,9 +255,7 @@ class ImageTest(unittest.TestCase):
 
     def test_data_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_image_is_loaded.return_value = 0
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
@@ -310,9 +266,7 @@ class ImageTest(unittest.TestCase):
 
     def test_data_uri(self, lib_mock):
         lib_mock.sp_image_format.return_value = int(spotify.ImageFormat.JPEG)
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
 
         prop_mock = mock.PropertyMock()
@@ -326,9 +280,7 @@ class ImageTest(unittest.TestCase):
 
     def test_data_uri_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_image_is_loaded.return_value = 0
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
@@ -337,14 +289,10 @@ class ImageTest(unittest.TestCase):
         self.assertIsNone(result)
 
     def test_data_uri_fails_if_unknown_image_format(self, lib_mock):
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         image = spotify.Image(self.session, sp_image=sp_image)
-        image.__dict__['format'] = mock.Mock(
-            return_value=spotify.ImageFormat.UNKNOWN
-        )
+        image.__dict__['format'] = mock.Mock(return_value=spotify.ImageFormat.UNKNOWN)
         image.__dict__['data'] = mock.Mock(return_value=b'01234\x006789')
 
         with self.assertRaises(ValueError):
@@ -352,9 +300,7 @@ class ImageTest(unittest.TestCase):
 
     @mock.patch('spotify.Link', spec=spotify.Link)
     def test_link_creates_link_to_image(self, link_mock, lib_mock):
-        lib_mock.sp_image_add_load_callback.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         sp_image = spotify.ffi.cast('sp_image *', 42)
         image = spotify.Image(self.session, sp_image=sp_image)
         sp_link = spotify.ffi.cast('sp_link *', 43)
@@ -363,9 +309,7 @@ class ImageTest(unittest.TestCase):
 
         result = image.link
 
-        link_mock.assert_called_once_with(
-            self.session, sp_link=sp_link, add_ref=False
-        )
+        link_mock.assert_called_once_with(self.session, sp_link=sp_link, add_ref=False)
         self.assertEqual(result, mock.sentinel.link)
 
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -7,7 +7,7 @@ import tests
 from tests import mock
 
 
-@mock.patch('spotify.image.lib', spec=spotify.lib)
+@mock.patch("spotify.image.lib", spec=spotify.lib)
 class ImageTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
@@ -20,16 +20,16 @@ class ImageTest(unittest.TestCase):
         with self.assertRaises(AssertionError):
             spotify.Image(self.session)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_create_from_uri(self, link_mock, lib_mock):
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         link_instance_mock = link_mock.return_value
         link_instance_mock.as_image.return_value = spotify.Image(
             self.session, sp_image=sp_image
         )
         lib_mock.sp_image_create_from_link.return_value = sp_image
-        uri = 'spotify:image:foo'
+        uri = "spotify:image:foo"
 
         result = spotify.Image(self.session, uri=uri)
 
@@ -38,18 +38,18 @@ class ImageTest(unittest.TestCase):
         lib_mock.sp_image_add_ref.assert_called_with(sp_image)
         self.assertEqual(result._sp_image, sp_image)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_create_from_uri_fail_raises_error(self, link_mock, lib_mock):
         link_instance_mock = link_mock.return_value
         link_instance_mock.as_image.return_value = None
-        uri = 'spotify:image:foo'
+        uri = "spotify:image:foo"
 
         with self.assertRaises(ValueError):
             spotify.Image(self.session, uri=uri)
 
     def test_adds_ref_to_sp_image_when_created(self, lib_mock):
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
 
         spotify.Image(self.session, sp_image=sp_image)
 
@@ -57,7 +57,7 @@ class ImageTest(unittest.TestCase):
 
     def test_releases_sp_image_when_image_dies(self, lib_mock):
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
 
         image = spotify.Image(self.session, sp_image=sp_image)
         image = None  # noqa
@@ -65,30 +65,30 @@ class ImageTest(unittest.TestCase):
 
         lib_mock.sp_image_release.assert_called_with(sp_image)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_repr(self, link_mock, lib_mock):
         link_instance_mock = link_mock.return_value
-        link_instance_mock.uri = 'foo'
+        link_instance_mock.uri = "foo"
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
         result = repr(image)
 
-        self.assertEqual(result, 'Image(%r)' % 'foo')
+        self.assertEqual(result, "Image(%r)" % "foo")
 
     def test_eq(self, lib_mock):
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         image1 = spotify.Image(self.session, sp_image=sp_image)
         image2 = spotify.Image(self.session, sp_image=sp_image)
 
         self.assertTrue(image1 == image2)
-        self.assertFalse(image1 == 'foo')
+        self.assertFalse(image1 == "foo")
 
     def test_ne(self, lib_mock):
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         image1 = spotify.Image(self.session, sp_image=sp_image)
         image2 = spotify.Image(self.session, sp_image=sp_image)
 
@@ -96,7 +96,7 @@ class ImageTest(unittest.TestCase):
 
     def test_hash(self, lib_mock):
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         image1 = spotify.Image(self.session, sp_image=sp_image)
         image2 = spotify.Image(self.session, sp_image=sp_image)
 
@@ -104,7 +104,7 @@ class ImageTest(unittest.TestCase):
 
     def test_loaded_event_is_unset_by_default(self, lib_mock):
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
         self.assertFalse(image.loaded_event.is_set())
@@ -112,7 +112,7 @@ class ImageTest(unittest.TestCase):
     def test_create_with_callback(self, lib_mock):
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         lib_mock.sp_image_remove_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         lib_mock.sp_image_create.return_value = sp_image
         callback = mock.Mock()
 
@@ -142,7 +142,7 @@ class ImageTest(unittest.TestCase):
 
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
         lib_mock.sp_image_remove_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         lib_mock.sp_image_create.return_value = sp_image
         callback = mock.Mock()
 
@@ -171,7 +171,7 @@ class ImageTest(unittest.TestCase):
         lib_mock.sp_image_add_load_callback.return_value = int(
             spotify.ErrorType.BAD_API_VERSION
         )
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         callback = mock.Mock()
 
         with self.assertRaises(spotify.Error):
@@ -180,7 +180,7 @@ class ImageTest(unittest.TestCase):
     def test_is_loaded(self, lib_mock):
         lib_mock.sp_image_is_loaded.return_value = 1
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
         result = image.is_loaded
@@ -191,7 +191,7 @@ class ImageTest(unittest.TestCase):
     def test_error(self, lib_mock):
         lib_mock.sp_image_error.return_value = int(spotify.ErrorType.IS_LOADING)
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
         result = image.error
@@ -199,10 +199,10 @@ class ImageTest(unittest.TestCase):
         lib_mock.sp_image_error.assert_called_once_with(sp_image)
         self.assertIs(result, spotify.ErrorType.IS_LOADING)
 
-    @mock.patch('spotify.utils.load')
+    @mock.patch("spotify.utils.load")
     def test_load(self, load_mock, lib_mock):
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
         image.load(10)
@@ -213,7 +213,7 @@ class ImageTest(unittest.TestCase):
         lib_mock.sp_image_is_loaded.return_value = 1
         lib_mock.sp_image_format.return_value = int(spotify.ImageFormat.JPEG)
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
         result = image.format
@@ -224,7 +224,7 @@ class ImageTest(unittest.TestCase):
     def test_format_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_image_is_loaded.return_value = 0
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
         result = image.format
@@ -236,27 +236,27 @@ class ImageTest(unittest.TestCase):
         lib_mock.sp_image_is_loaded.return_value = 1
 
         size = 20
-        data = spotify.ffi.new('char[]', size)
-        data[0:3] = [b'a', b'b', b'c']
+        data = spotify.ffi.new("char[]", size)
+        data[0:3] = [b"a", b"b", b"c"]
 
         def func(sp_image_ptr, data_size_ptr):
             data_size_ptr[0] = size
-            return spotify.ffi.cast('void *', data)
+            return spotify.ffi.cast("void *", data)
 
         lib_mock.sp_image_data.side_effect = func
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
         result = image.data
 
         lib_mock.sp_image_data.assert_called_with(sp_image, mock.ANY)
-        self.assertEqual(result[:5], b'abc\x00\x00')
+        self.assertEqual(result[:5], b"abc\x00\x00")
 
     def test_data_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_image_is_loaded.return_value = 0
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
         result = image.data
@@ -267,21 +267,21 @@ class ImageTest(unittest.TestCase):
     def test_data_uri(self, lib_mock):
         lib_mock.sp_image_format.return_value = int(spotify.ImageFormat.JPEG)
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
 
         prop_mock = mock.PropertyMock()
-        with mock.patch.object(spotify.Image, 'data', prop_mock):
+        with mock.patch.object(spotify.Image, "data", prop_mock):
             image = spotify.Image(self.session, sp_image=sp_image)
-            prop_mock.return_value = b'01234\x006789'
+            prop_mock.return_value = b"01234\x006789"
 
             result = image.data_uri
 
-        self.assertEqual(result, 'data:image/jpeg;base64,MDEyMzQANjc4OQ==')
+        self.assertEqual(result, "data:image/jpeg;base64,MDEyMzQANjc4OQ==")
 
     def test_data_uri_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_image_is_loaded.return_value = 0
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         image = spotify.Image(self.session, sp_image=sp_image)
 
         result = image.data_uri
@@ -290,20 +290,20 @@ class ImageTest(unittest.TestCase):
 
     def test_data_uri_fails_if_unknown_image_format(self, lib_mock):
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         image = spotify.Image(self.session, sp_image=sp_image)
-        image.__dict__['format'] = mock.Mock(return_value=spotify.ImageFormat.UNKNOWN)
-        image.__dict__['data'] = mock.Mock(return_value=b'01234\x006789')
+        image.__dict__["format"] = mock.Mock(return_value=spotify.ImageFormat.UNKNOWN)
+        image.__dict__["data"] = mock.Mock(return_value=b"01234\x006789")
 
         with self.assertRaises(ValueError):
             image.data_uri
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_link_creates_link_to_image(self, link_mock, lib_mock):
         lib_mock.sp_image_add_load_callback.return_value = int(spotify.ErrorType.OK)
-        sp_image = spotify.ffi.cast('sp_image *', 42)
+        sp_image = spotify.ffi.cast("sp_image *", 42)
         image = spotify.Image(self.session, sp_image=sp_image)
-        sp_link = spotify.ffi.cast('sp_link *', 43)
+        sp_link = spotify.ffi.cast("sp_link *", 43)
         lib_mock.sp_link_create_from_image.return_value = sp_link
         link_mock.return_value = mock.sentinel.link
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-
 import tests
 from tests import mock
 

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -9,7 +9,7 @@ import tests
 from tests import mock
 
 
-@mock.patch('spotify.inbox.lib', spec=spotify.lib)
+@mock.patch("spotify.inbox.lib", spec=spotify.lib)
 class InboxPostResultTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
@@ -23,14 +23,14 @@ class InboxPostResultTest(unittest.TestCase):
             spotify.InboxPostResult(self.session)
 
     def test_adds_ref_to_sp_inbox_when_created(self, lib_mock):
-        sp_inbox = spotify.ffi.cast('sp_inbox *', 42)
+        sp_inbox = spotify.ffi.cast("sp_inbox *", 42)
 
         spotify.InboxPostResult(self.session, sp_inbox=sp_inbox)
 
         lib_mock.sp_inbox_add_ref.assert_called_with(sp_inbox)
 
     def test_releases_sp_inbox_when_result_dies(self, lib_mock):
-        sp_inbox = spotify.ffi.cast('sp_inbox *', 42)
+        sp_inbox = spotify.ffi.cast("sp_inbox *", 42)
 
         inbox_post_result = spotify.InboxPostResult(self.session, sp_inbox=sp_inbox)
         inbox_post_result = None  # noqa
@@ -38,16 +38,16 @@ class InboxPostResultTest(unittest.TestCase):
 
         lib_mock.sp_inbox_release.assert_called_with(sp_inbox)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_inbox_post_tracks(self, track_lib_mock, lib_mock):
-        sp_track1 = spotify.ffi.cast('sp_track *', 43)
+        sp_track1 = spotify.ffi.cast("sp_track *", 43)
         track1 = spotify.Track(self.session, sp_track=sp_track1)
-        sp_track2 = spotify.ffi.cast('sp_track *', 44)
+        sp_track2 = spotify.ffi.cast("sp_track *", 44)
         track2 = spotify.Track(self.session, sp_track=sp_track2)
-        sp_inbox = spotify.ffi.cast('sp_inbox *', 42)
+        sp_inbox = spotify.ffi.cast("sp_inbox *", 42)
         lib_mock.sp_inbox_post_tracks.return_value = sp_inbox
 
-        result = spotify.InboxPostResult(self.session, 'alice', [track1, track2], '♥')
+        result = spotify.InboxPostResult(self.session, "alice", [track1, track2], "♥")
 
         lib_mock.sp_inbox_post_tracks.assert_called_with(
             self.session._sp_session,
@@ -60,13 +60,13 @@ class InboxPostResultTest(unittest.TestCase):
         )
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_inbox_post_tracks.call_args[0][1]),
-            b'alice',
+            b"alice",
         )
         self.assertIn(sp_track1, lib_mock.sp_inbox_post_tracks.call_args[0][2])
         self.assertIn(sp_track2, lib_mock.sp_inbox_post_tracks.call_args[0][2])
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_inbox_post_tracks.call_args[0][4]),
-            b'\xe2\x99\xa5',
+            b"\xe2\x99\xa5",
         )
         self.assertIsInstance(result, spotify.InboxPostResult)
         self.assertEqual(result._sp_inbox, sp_inbox)
@@ -77,14 +77,14 @@ class InboxPostResultTest(unittest.TestCase):
         inboxpost_complete_cb(sp_inbox, userdata)
         self.assertTrue(result.loaded_event.wait(3))
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_inbox_post_with_single_track(self, track_lib_mock, lib_mock):
-        sp_track1 = spotify.ffi.cast('sp_track *', 43)
+        sp_track1 = spotify.ffi.cast("sp_track *", 43)
         track1 = spotify.Track(self.session, sp_track=sp_track1)
-        sp_inbox = spotify.ffi.cast('sp_inbox *', 42)
+        sp_inbox = spotify.ffi.cast("sp_inbox *", 42)
         lib_mock.sp_inbox_post_tracks.return_value = sp_inbox
 
-        result = spotify.InboxPostResult(self.session, 'alice', track1, 'Enjoy!')
+        result = spotify.InboxPostResult(self.session, "alice", track1, "Enjoy!")
 
         lib_mock.sp_inbox_post_tracks.assert_called_with(
             self.session._sp_session,
@@ -99,18 +99,18 @@ class InboxPostResultTest(unittest.TestCase):
         self.assertIsInstance(result, spotify.InboxPostResult)
         self.assertEqual(result._sp_inbox, sp_inbox)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_inbox_post_with_callback(self, track_lib_mock, lib_mock):
-        sp_track1 = spotify.ffi.cast('sp_track *', 43)
+        sp_track1 = spotify.ffi.cast("sp_track *", 43)
         track1 = spotify.Track(self.session, sp_track=sp_track1)
-        sp_track2 = spotify.ffi.cast('sp_track *', 44)
+        sp_track2 = spotify.ffi.cast("sp_track *", 44)
         track2 = spotify.Track(self.session, sp_track=sp_track2)
-        sp_inbox = spotify.ffi.cast('sp_inbox *', 42)
+        sp_inbox = spotify.ffi.cast("sp_inbox *", 42)
         lib_mock.sp_inbox_post_tracks.return_value = sp_inbox
         callback = mock.Mock()
 
         result = spotify.InboxPostResult(
-            self.session, 'alice', [track1, track2], callback=callback
+            self.session, "alice", [track1, track2], callback=callback
         )
 
         inboxpost_complete_cb = lib_mock.sp_inbox_post_tracks.call_args[0][5]
@@ -120,21 +120,21 @@ class InboxPostResultTest(unittest.TestCase):
         result.loaded_event.wait(3)
         callback.assert_called_with(result)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_inbox_post_where_result_is_gone_before_callback_is_called(
         self, track_lib_mock, lib_mock
     ):
 
-        sp_track1 = spotify.ffi.cast('sp_track *', 43)
+        sp_track1 = spotify.ffi.cast("sp_track *", 43)
         track1 = spotify.Track(self.session, sp_track=sp_track1)
-        sp_track2 = spotify.ffi.cast('sp_track *', 44)
+        sp_track2 = spotify.ffi.cast("sp_track *", 44)
         track2 = spotify.Track(self.session, sp_track=sp_track2)
-        sp_inbox = spotify.ffi.cast('sp_inbox *', 42)
+        sp_inbox = spotify.ffi.cast("sp_inbox *", 42)
         lib_mock.sp_inbox_post_tracks.return_value = sp_inbox
         callback = mock.Mock()
 
         result = spotify.InboxPostResult(
-            self.session, 'alice', [track1, track2], callback=callback
+            self.session, "alice", [track1, track2], callback=callback
         )
         loaded_event = result.loaded_event
         result = None  # noqa
@@ -150,49 +150,49 @@ class InboxPostResultTest(unittest.TestCase):
         self.assertEqual(callback.call_count, 1)
         self.assertEqual(callback.call_args[0][0]._sp_inbox, sp_inbox)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_fail_to_init_raises_error(self, track_lib_mock, lib_mock):
-        sp_track1 = spotify.ffi.cast('sp_track *', 43)
+        sp_track1 = spotify.ffi.cast("sp_track *", 43)
         track1 = spotify.Track(self.session, sp_track=sp_track1)
-        sp_track2 = spotify.ffi.cast('sp_track *', 44)
+        sp_track2 = spotify.ffi.cast("sp_track *", 44)
         track2 = spotify.Track(self.session, sp_track=sp_track2)
         lib_mock.sp_inbox_post_tracks.return_value = spotify.ffi.NULL
 
         with self.assertRaises(spotify.Error):
-            spotify.InboxPostResult(self.session, 'alice', [track1, track2], 'Enjoy!')
+            spotify.InboxPostResult(self.session, "alice", [track1, track2], "Enjoy!")
 
     def test_repr(self, lib_mock):
-        sp_inbox = spotify.ffi.cast('sp_inbox *', 42)
+        sp_inbox = spotify.ffi.cast("sp_inbox *", 42)
         inbox_post_result = spotify.InboxPostResult(self.session, sp_inbox=sp_inbox)
 
-        self.assertEqual(repr(inbox_post_result), 'InboxPostResult(<pending>)')
+        self.assertEqual(repr(inbox_post_result), "InboxPostResult(<pending>)")
 
         inbox_post_result.loaded_event.set()
         lib_mock.sp_inbox_error.return_value = int(spotify.ErrorType.INBOX_IS_FULL)
 
-        self.assertEqual(repr(inbox_post_result), 'InboxPostResult(INBOX_IS_FULL)')
+        self.assertEqual(repr(inbox_post_result), "InboxPostResult(INBOX_IS_FULL)")
 
         lib_mock.sp_inbox_error.return_value = int(spotify.ErrorType.OK)
 
-        self.assertEqual(repr(inbox_post_result), 'InboxPostResult(OK)')
+        self.assertEqual(repr(inbox_post_result), "InboxPostResult(OK)")
 
     def test_eq(self, lib_mock):
-        sp_inbox = spotify.ffi.cast('sp_inbox *', 42)
+        sp_inbox = spotify.ffi.cast("sp_inbox *", 42)
         inbox1 = spotify.InboxPostResult(self.session, sp_inbox=sp_inbox)
         inbox2 = spotify.InboxPostResult(self.session, sp_inbox=sp_inbox)
 
         self.assertTrue(inbox1 == inbox2)
-        self.assertFalse(inbox1 == 'foo')
+        self.assertFalse(inbox1 == "foo")
 
     def test_ne(self, lib_mock):
-        sp_inbox = spotify.ffi.cast('sp_inbox *', 42)
+        sp_inbox = spotify.ffi.cast("sp_inbox *", 42)
         inbox1 = spotify.InboxPostResult(self.session, sp_inbox=sp_inbox)
         inbox2 = spotify.InboxPostResult(self.session, sp_inbox=sp_inbox)
 
         self.assertFalse(inbox1 != inbox2)
 
     def test_hash(self, lib_mock):
-        sp_inbox = spotify.ffi.cast('sp_inbox *', 42)
+        sp_inbox = spotify.ffi.cast("sp_inbox *", 42)
         inbox1 = spotify.InboxPostResult(self.session, sp_inbox=sp_inbox)
         inbox2 = spotify.InboxPostResult(self.session, sp_inbox=sp_inbox)
 
@@ -200,7 +200,7 @@ class InboxPostResultTest(unittest.TestCase):
 
     def test_error(self, lib_mock):
         lib_mock.sp_inbox_error.return_value = int(spotify.ErrorType.INBOX_IS_FULL)
-        sp_inbox = spotify.ffi.cast('sp_inbox *', 42)
+        sp_inbox = spotify.ffi.cast("sp_inbox *", 42)
         inbox_post_result = spotify.InboxPostResult(self.session, sp_inbox=sp_inbox)
 
         result = inbox_post_result.error

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -32,9 +32,7 @@ class InboxPostResultTest(unittest.TestCase):
     def test_releases_sp_inbox_when_result_dies(self, lib_mock):
         sp_inbox = spotify.ffi.cast('sp_inbox *', 42)
 
-        inbox_post_result = spotify.InboxPostResult(
-            self.session, sp_inbox=sp_inbox
-        )
+        inbox_post_result = spotify.InboxPostResult(self.session, sp_inbox=sp_inbox)
         inbox_post_result = None  # noqa
         tests.gc_collect()
 
@@ -49,9 +47,7 @@ class InboxPostResultTest(unittest.TestCase):
         sp_inbox = spotify.ffi.cast('sp_inbox *', 42)
         lib_mock.sp_inbox_post_tracks.return_value = sp_inbox
 
-        result = spotify.InboxPostResult(
-            self.session, 'alice', [track1, track2], '♥'
-        )
+        result = spotify.InboxPostResult(self.session, 'alice', [track1, track2], '♥')
 
         lib_mock.sp_inbox_post_tracks.assert_called_with(
             self.session._sp_session,
@@ -88,9 +84,7 @@ class InboxPostResultTest(unittest.TestCase):
         sp_inbox = spotify.ffi.cast('sp_inbox *', 42)
         lib_mock.sp_inbox_post_tracks.return_value = sp_inbox
 
-        result = spotify.InboxPostResult(
-            self.session, 'alice', track1, 'Enjoy!'
-        )
+        result = spotify.InboxPostResult(self.session, 'alice', track1, 'Enjoy!')
 
         lib_mock.sp_inbox_post_tracks.assert_called_with(
             self.session._sp_session,
@@ -165,26 +159,18 @@ class InboxPostResultTest(unittest.TestCase):
         lib_mock.sp_inbox_post_tracks.return_value = spotify.ffi.NULL
 
         with self.assertRaises(spotify.Error):
-            spotify.InboxPostResult(
-                self.session, 'alice', [track1, track2], 'Enjoy!'
-            )
+            spotify.InboxPostResult(self.session, 'alice', [track1, track2], 'Enjoy!')
 
     def test_repr(self, lib_mock):
         sp_inbox = spotify.ffi.cast('sp_inbox *', 42)
-        inbox_post_result = spotify.InboxPostResult(
-            self.session, sp_inbox=sp_inbox
-        )
+        inbox_post_result = spotify.InboxPostResult(self.session, sp_inbox=sp_inbox)
 
         self.assertEqual(repr(inbox_post_result), 'InboxPostResult(<pending>)')
 
         inbox_post_result.loaded_event.set()
-        lib_mock.sp_inbox_error.return_value = int(
-            spotify.ErrorType.INBOX_IS_FULL
-        )
+        lib_mock.sp_inbox_error.return_value = int(spotify.ErrorType.INBOX_IS_FULL)
 
-        self.assertEqual(
-            repr(inbox_post_result), 'InboxPostResult(INBOX_IS_FULL)'
-        )
+        self.assertEqual(repr(inbox_post_result), 'InboxPostResult(INBOX_IS_FULL)')
 
         lib_mock.sp_inbox_error.return_value = int(spotify.ErrorType.OK)
 
@@ -213,13 +199,9 @@ class InboxPostResultTest(unittest.TestCase):
         self.assertEqual(hash(inbox1), hash(inbox2))
 
     def test_error(self, lib_mock):
-        lib_mock.sp_inbox_error.return_value = int(
-            spotify.ErrorType.INBOX_IS_FULL
-        )
+        lib_mock.sp_inbox_error.return_value = int(spotify.ErrorType.INBOX_IS_FULL)
         sp_inbox = spotify.ffi.cast('sp_inbox *', 42)
-        inbox_post_result = spotify.InboxPostResult(
-            self.session, sp_inbox=sp_inbox
-        )
+        inbox_post_result = spotify.InboxPostResult(self.session, sp_inbox=sp_inbox)
 
         result = inbox_post_result.error
 

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-
 import tests
 from tests import mock
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -8,7 +8,7 @@ import spotify
 class LibTest(unittest.TestCase):
     def test_sp_error_message(self):
         self.assertEqual(
-            spotify.ffi.string(spotify.lib.sp_error_message(0)), b'No error'
+            spotify.ffi.string(spotify.lib.sp_error_message(0)), b"No error"
         )
 
     def test_SPOTIFY_API_VERSION_macro(self):

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -31,9 +31,7 @@ class LinkTest(unittest.TestCase):
 
         lib_mock.sp_link_create_from_string.assert_called_once_with(mock.ANY)
         self.assertEqual(
-            spotify.ffi.string(
-                lib_mock.sp_link_create_from_string.call_args[0][0]
-            ),
+            spotify.ffi.string(lib_mock.sp_link_create_from_string.call_args[0][0]),
             b'spotify:track:foo',
         )
         self.assertEqual(lib_mock.sp_link_add_ref.call_count, 0)
@@ -46,9 +44,7 @@ class LinkTest(unittest.TestCase):
 
         lib_mock.sp_link_create_from_string.assert_called_once_with(mock.ANY)
         self.assertEqual(
-            spotify.ffi.string(
-                lib_mock.sp_link_create_from_string.call_args[0][0]
-            ),
+            spotify.ffi.string(lib_mock.sp_link_create_from_string.call_args[0][0]),
             b'spotify:track:bar',
         )
 
@@ -56,15 +52,11 @@ class LinkTest(unittest.TestCase):
         sp_link = spotify.ffi.cast('sp_link *', 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
 
-        spotify.Link(
-            self.session, 'https://play.spotify.com/track/bar?gurba=123'
-        )
+        spotify.Link(self.session, 'https://play.spotify.com/track/bar?gurba=123')
 
         lib_mock.sp_link_create_from_string.assert_called_once_with(mock.ANY)
         self.assertEqual(
-            spotify.ffi.string(
-                lib_mock.sp_link_create_from_string.call_args[0][0]
-            ),
+            spotify.ffi.string(lib_mock.sp_link_create_from_string.call_args[0][0]),
             b'spotify:track:bar',
         )
 
@@ -138,9 +130,7 @@ class LinkTest(unittest.TestCase):
 
         result = link.uri
 
-        lib_mock.sp_link_as_string.assert_called_with(
-            sp_link, mock.ANY, mock.ANY
-        )
+        lib_mock.sp_link_as_string.assert_called_with(sp_link, mock.ANY, mock.ANY)
         self.assertEqual(result, string)
 
     def test_url_expands_uri_to_http_url(self, lib_mock):
@@ -203,14 +193,10 @@ class LinkTest(unittest.TestCase):
         offset = link.as_track_offset()
 
         self.assertEqual(offset, 90)
-        lib_mock.sp_link_as_track_and_offset.assert_called_once_with(
-            sp_link, mock.ANY
-        )
+        lib_mock.sp_link_as_track_and_offset.assert_called_once_with(sp_link, mock.ANY)
 
     @mock.patch('spotify.track.lib', spec=spotify.lib)
-    def test_as_track_with_offset_if_not_a_track(
-        self, track_lib_mock, lib_mock
-    ):
+    def test_as_track_with_offset_if_not_a_track(self, track_lib_mock, lib_mock):
         sp_link = spotify.ffi.cast('sp_link *', 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
         lib_mock.sp_link_as_track_and_offset.return_value = spotify.ffi.NULL
@@ -219,9 +205,7 @@ class LinkTest(unittest.TestCase):
         offset = link.as_track_offset()
 
         self.assertIsNone(offset)
-        lib_mock.sp_link_as_track_and_offset.assert_called_once_with(
-            sp_link, mock.ANY
-        )
+        lib_mock.sp_link_as_track_and_offset.assert_called_once_with(sp_link, mock.ANY)
 
     @mock.patch('spotify.album.lib', spec=spotify.lib)
     def test_as_album(self, album_lib_mock, lib_mock):

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -7,7 +7,7 @@ import tests
 from tests import mock
 
 
-@mock.patch('spotify.link.lib', spec=spotify.lib)
+@mock.patch("spotify.link.lib", spec=spotify.lib)
 class LinkTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
@@ -17,81 +17,81 @@ class LinkTest(unittest.TestCase):
             spotify.Link(self.session)
 
     def test_create_from_sp_link(self, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
 
         result = spotify.Link(self.session, sp_link=sp_link)
 
         self.assertEqual(result._sp_link, sp_link)
 
     def test_create_from_uri(self, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
 
-        spotify.Link(self.session, 'spotify:track:foo')
+        spotify.Link(self.session, "spotify:track:foo")
 
         lib_mock.sp_link_create_from_string.assert_called_once_with(mock.ANY)
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_link_create_from_string.call_args[0][0]),
-            b'spotify:track:foo',
+            b"spotify:track:foo",
         )
         self.assertEqual(lib_mock.sp_link_add_ref.call_count, 0)
 
     def test_create_from_open_spotify_com_url(self, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
 
-        spotify.Link(self.session, 'http://open.spotify.com/track/bar ')
+        spotify.Link(self.session, "http://open.spotify.com/track/bar ")
 
         lib_mock.sp_link_create_from_string.assert_called_once_with(mock.ANY)
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_link_create_from_string.call_args[0][0]),
-            b'spotify:track:bar',
+            b"spotify:track:bar",
         )
 
     def test_create_from_play_spotify_com_url(self, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
 
-        spotify.Link(self.session, 'https://play.spotify.com/track/bar?gurba=123')
+        spotify.Link(self.session, "https://play.spotify.com/track/bar?gurba=123")
 
         lib_mock.sp_link_create_from_string.assert_called_once_with(mock.ANY)
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_link_create_from_string.call_args[0][0]),
-            b'spotify:track:bar',
+            b"spotify:track:bar",
         )
 
     def test_raises_error_if_string_isnt_parseable(self, lib_mock):
         lib_mock.sp_link_create_from_string.return_value = spotify.ffi.NULL
 
         with self.assertRaises(ValueError):
-            spotify.Link(self.session, 'invalid link string')
+            spotify.Link(self.session, "invalid link string")
 
     def test_releases_sp_link_when_link_dies(self, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
 
-        link = spotify.Link(self.session, 'spotify:track:foo')
+        link = spotify.Link(self.session, "spotify:track:foo")
         link = None  # noqa
         tests.gc_collect()
 
         lib_mock.sp_link_release.assert_called_with(sp_link)
 
     def test_repr(self, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
-        string = 'foo'
+        string = "foo"
 
         lib_mock.sp_link_as_string.side_effect = tests.buffer_writer(string)
         link = spotify.Link(self.session, string)
 
         result = repr(link)
 
-        self.assertEqual(result, 'Link(%r)' % string)
+        self.assertEqual(result, "Link(%r)" % string)
 
     def test_str(self, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
-        string = 'foo'
+        string = "foo"
 
         lib_mock.sp_link_as_string.side_effect = tests.buffer_writer(string)
         link = spotify.Link(self.session, string)
@@ -99,31 +99,31 @@ class LinkTest(unittest.TestCase):
         self.assertEqual(str(link), link.uri)
 
     def test_eq(self, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         link1 = spotify.Link(self.session, sp_link=sp_link)
         link2 = spotify.Link(self.session, sp_link=sp_link)
 
         self.assertTrue(link1 == link2)
-        self.assertFalse(link1 == 'foo')
+        self.assertFalse(link1 == "foo")
 
     def test_ne(self, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         link1 = spotify.Link(self.session, sp_link=sp_link)
         link2 = spotify.Link(self.session, sp_link=sp_link)
 
         self.assertFalse(link1 != link2)
 
     def test_hash(self, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         link1 = spotify.Link(self.session, sp_link=sp_link)
         link2 = spotify.Link(self.session, sp_link=sp_link)
 
         self.assertEqual(hash(link1), hash(link2))
 
     def test_uri_grows_buffer_to_fit_link(self, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
-        string = 'foo' * 100
+        string = "foo" * 100
 
         lib_mock.sp_link_as_string.side_effect = tests.buffer_writer(string)
         link = spotify.Link(self.session, string)
@@ -134,54 +134,54 @@ class LinkTest(unittest.TestCase):
         self.assertEqual(result, string)
 
     def test_url_expands_uri_to_http_url(self, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
-        string = 'spotify:track:foo'
+        string = "spotify:track:foo"
         lib_mock.sp_link_as_string.side_effect = tests.buffer_writer(string)
         link = spotify.Link(self.session, string)
 
         result = link.url
 
-        self.assertEqual(result, 'https://open.spotify.com/track/foo')
+        self.assertEqual(result, "https://open.spotify.com/track/foo")
 
     def test_type(self, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
         lib_mock.sp_link_type.return_value = 1
-        link = spotify.Link(self.session, 'spotify:track:foo')
+        link = spotify.Link(self.session, "spotify:track:foo")
 
         self.assertIs(link.type, spotify.LinkType.TRACK)
 
         lib_mock.sp_link_type.assert_called_once_with(sp_link)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_as_track(self, track_lib_mock, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
-        sp_track = spotify.ffi.cast('sp_track *', 43)
+        sp_track = spotify.ffi.cast("sp_track *", 43)
         lib_mock.sp_link_as_track.return_value = sp_track
 
-        link = spotify.Link(self.session, 'spotify:track:foo')
+        link = spotify.Link(self.session, "spotify:track:foo")
         self.assertEqual(link.as_track()._sp_track, sp_track)
 
         lib_mock.sp_link_as_track.assert_called_once_with(sp_link)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_as_track_if_not_a_track(self, track_lib_mock, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
         lib_mock.sp_link_as_track.return_value = spotify.ffi.NULL
 
-        link = spotify.Link(self.session, 'spotify:track:foo')
+        link = spotify.Link(self.session, "spotify:track:foo")
         self.assertIsNone(link.as_track())
 
         lib_mock.sp_link_as_track.assert_called_once_with(sp_link)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_as_track_with_offset(self, track_lib_mock, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
-        sp_track = spotify.ffi.cast('sp_track *', 43)
+        sp_track = spotify.ffi.cast("sp_track *", 43)
 
         def func(sp_link, offset_ptr):
             offset_ptr[0] = 90
@@ -189,79 +189,79 @@ class LinkTest(unittest.TestCase):
 
         lib_mock.sp_link_as_track_and_offset.side_effect = func
 
-        link = spotify.Link(self.session, 'spotify:track:foo')
+        link = spotify.Link(self.session, "spotify:track:foo")
         offset = link.as_track_offset()
 
         self.assertEqual(offset, 90)
         lib_mock.sp_link_as_track_and_offset.assert_called_once_with(sp_link, mock.ANY)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_as_track_with_offset_if_not_a_track(self, track_lib_mock, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
         lib_mock.sp_link_as_track_and_offset.return_value = spotify.ffi.NULL
 
-        link = spotify.Link(self.session, 'spotify:track:foo')
+        link = spotify.Link(self.session, "spotify:track:foo")
         offset = link.as_track_offset()
 
         self.assertIsNone(offset)
         lib_mock.sp_link_as_track_and_offset.assert_called_once_with(sp_link, mock.ANY)
 
-    @mock.patch('spotify.album.lib', spec=spotify.lib)
+    @mock.patch("spotify.album.lib", spec=spotify.lib)
     def test_as_album(self, album_lib_mock, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
-        sp_album = spotify.ffi.cast('sp_album *', 43)
+        sp_album = spotify.ffi.cast("sp_album *", 43)
         lib_mock.sp_link_as_album.return_value = sp_album
 
-        link = spotify.Link(self.session, 'spotify:album:foo')
+        link = spotify.Link(self.session, "spotify:album:foo")
         self.assertEqual(link.as_album()._sp_album, sp_album)
 
         lib_mock.sp_link_as_album.assert_called_once_with(sp_link)
 
-    @mock.patch('spotify.album.lib', spec=spotify.lib)
+    @mock.patch("spotify.album.lib", spec=spotify.lib)
     def test_as_album_if_not_an_album(self, album_lib_mock, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
         lib_mock.sp_link_as_album.return_value = spotify.ffi.NULL
 
-        link = spotify.Link(self.session, 'spotify:album:foo')
+        link = spotify.Link(self.session, "spotify:album:foo")
         self.assertIsNone(link.as_album())
 
         lib_mock.sp_link_as_album.assert_called_once_with(sp_link)
 
-    @mock.patch('spotify.artist.lib', spec=spotify.lib)
+    @mock.patch("spotify.artist.lib", spec=spotify.lib)
     def test_as_artist(self, artist_lib_mock, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
-        sp_artist = spotify.ffi.cast('sp_artist *', 43)
+        sp_artist = spotify.ffi.cast("sp_artist *", 43)
         lib_mock.sp_link_as_artist.return_value = sp_artist
 
-        link = spotify.Link(self.session, 'spotify:artist:foo')
+        link = spotify.Link(self.session, "spotify:artist:foo")
         self.assertEqual(link.as_artist()._sp_artist, sp_artist)
 
         lib_mock.sp_link_as_artist.assert_called_once_with(sp_link)
 
-    @mock.patch('spotify.artist.lib', spec=spotify.lib)
+    @mock.patch("spotify.artist.lib", spec=spotify.lib)
     def test_as_artist_if_not_an_artist(self, artist_lib_mock, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
         lib_mock.sp_link_as_artist.return_value = spotify.ffi.NULL
 
-        link = spotify.Link(self.session, 'spotify:artist:foo')
+        link = spotify.Link(self.session, "spotify:artist:foo")
         self.assertIsNone(link.as_artist())
 
         lib_mock.sp_link_as_artist.assert_called_once_with(sp_link)
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_as_playlist(self, playlist_lib_mock, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
         lib_mock.sp_link_type.return_value = spotify.LinkType.PLAYLIST
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlist_create.return_value = sp_playlist
 
-        link = spotify.Link(self.session, 'spotify:playlist:foo')
+        link = spotify.Link(self.session, "spotify:playlist:foo")
         self.assertEqual(link.as_playlist()._sp_playlist, sp_playlist)
 
         lib_mock.sp_playlist_create.assert_called_once_with(
@@ -273,68 +273,68 @@ class LinkTest(unittest.TestCase):
         # an Playlist object
         self.assertEqual(playlist_lib_mock.sp_playlist_add_ref.call_count, 0)
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_as_playlist_if_starred(self, playlist_lib_mock, lib_mock):
-        uri = 'spotify:user:alice:starred'
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        uri = "spotify:user:alice:starred"
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
         lib_mock.sp_link_type.return_value = spotify.LinkType.STARRED
         lib_mock.sp_link_as_string.side_effect = tests.buffer_writer(uri)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_session_starred_for_user_create.return_value = sp_playlist
 
         link = spotify.Link(self.session, uri)
         self.assertEqual(link.as_playlist()._sp_playlist, sp_playlist)
 
         lib_mock.sp_session_starred_for_user_create.assert_called_once_with(
-            self.session._sp_session, b'alice'
+            self.session._sp_session, b"alice"
         )
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_as_playlist_if_not_a_playlist(self, playlist_lib_mock, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
         lib_mock.sp_link_type.return_value = spotify.LinkType.ARTIST
 
-        link = spotify.Link(self.session, 'spotify:playlist:foo')
+        link = spotify.Link(self.session, "spotify:playlist:foo")
         self.assertIsNone(link.as_playlist())
 
         self.assertEqual(lib_mock.sp_playlist_create.call_count, 0)
 
-    @mock.patch('spotify.user.lib', spec=spotify.lib)
+    @mock.patch("spotify.user.lib", spec=spotify.lib)
     def test_as_user(self, user_lib_mock, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
-        sp_user = spotify.ffi.cast('sp_user *', 43)
+        sp_user = spotify.ffi.cast("sp_user *", 43)
         lib_mock.sp_link_as_user.return_value = sp_user
 
-        link = spotify.Link(self.session, 'spotify:user:foo')
+        link = spotify.Link(self.session, "spotify:user:foo")
         self.assertEqual(link.as_user()._sp_user, sp_user)
 
         lib_mock.sp_link_as_user.assert_called_once_with(sp_link)
 
-    @mock.patch('spotify.user.lib', spec=spotify.lib)
+    @mock.patch("spotify.user.lib", spec=spotify.lib)
     def test_as_user_if_not_a_user(self, user_lib_mock, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
         lib_mock.sp_link_as_user.return_value = spotify.ffi.NULL
 
-        link = spotify.Link(self.session, 'spotify:user:foo')
+        link = spotify.Link(self.session, "spotify:user:foo")
         self.assertIsNone(link.as_user())
 
         lib_mock.sp_link_as_user.assert_called_once_with(sp_link)
 
-    @mock.patch('spotify.Image', spec=spotify.Image)
+    @mock.patch("spotify.Image", spec=spotify.Image)
     def test_as_image(self, image_mock, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
         lib_mock.sp_link_type.return_value = spotify.LinkType.IMAGE
-        sp_image = spotify.ffi.cast('sp_image *', 43)
+        sp_image = spotify.ffi.cast("sp_image *", 43)
         lib_mock.sp_image_create_from_link.return_value = sp_image
         image_mock.return_value = mock.sentinel.image
         callback = mock.Mock()
 
-        link = spotify.Link(self.session, 'spotify:image:foo')
+        link = spotify.Link(self.session, "spotify:image:foo")
         result = link.as_image(callback=callback)
 
         self.assertIs(result, mock.sentinel.image)
@@ -350,11 +350,11 @@ class LinkTest(unittest.TestCase):
         )
 
     def test_as_image_if_not_a_image(self, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 42)
+        sp_link = spotify.ffi.cast("sp_link *", 42)
         lib_mock.sp_link_create_from_string.return_value = sp_link
         lib_mock.sp_link_type.return_value = spotify.LinkType.ARTIST
 
-        link = spotify.Link(self.session, 'spotify:image:foo')
+        link = spotify.Link(self.session, "spotify:image:foo")
         result = link.as_image()
 
         self.assertIsNone(result)

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-
 import tests
 from tests import mock
 

--- a/tests/test_loadable.py
+++ b/tests/test_loadable.py
@@ -27,8 +27,8 @@ class FooWithError(Foo):
         return spotify.Error(spotify.Error.OK)
 
 
-@mock.patch('spotify.utils.time')
-@mock.patch.object(Foo, 'is_loaded', new_callable=mock.PropertyMock)
+@mock.patch("spotify.utils.time")
+@mock.patch.object(Foo, "is_loaded", new_callable=mock.PropertyMock)
 class LoadableTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
@@ -80,7 +80,7 @@ class LoadableTest(unittest.TestCase):
         self.assertEqual(self.session.process_events.call_count, 2)
         self.assertEqual(time_mock.sleep.call_count, 2)
 
-    @mock.patch.object(FooWithError, 'error', new_callable=mock.PropertyMock)
+    @mock.patch.object(FooWithError, "error", new_callable=mock.PropertyMock)
     def test_load_raises_exception_on_error(
         self, error_mock, is_loaded_mock, time_mock
     ):

--- a/tests/test_loadable.py
+++ b/tests/test_loadable.py
@@ -4,9 +4,8 @@ import time
 import unittest
 
 import spotify
-from spotify.utils import load
-
 import tests
+from spotify.utils import load
 from tests import mock
 
 

--- a/tests/test_loadable.py
+++ b/tests/test_loadable.py
@@ -34,9 +34,7 @@ class LoadableTest(unittest.TestCase):
         self.session = tests.create_session_mock()
         self.session.connection.state = spotify.ConnectionState.LOGGED_IN
 
-    def test_load_raises_error_if_not_logged_in(
-        self, is_loaded_mock, time_mock
-    ):
+    def test_load_raises_error_if_not_logged_in(self, is_loaded_mock, time_mock):
         is_loaded_mock.return_value = False
         self.session.connection.state = spotify.ConnectionState.LOGGED_OUT
         foo = Foo(self.session)
@@ -64,9 +62,7 @@ class LoadableTest(unittest.TestCase):
         self.assertEqual(result, foo)
         self.assertEqual(self.session.process_events.call_count, 0)
 
-    def test_load_raises_error_when_timeout_is_reached(
-        self, is_loaded_mock, time_mock
-    ):
+    def test_load_raises_error_when_timeout_is_reached(self, is_loaded_mock, time_mock):
         is_loaded_mock.return_value = False
         time_mock.time.side_effect = time.time
         foo = Foo(self.session)
@@ -74,9 +70,7 @@ class LoadableTest(unittest.TestCase):
         with self.assertRaises(spotify.Timeout):
             foo.load(timeout=0)
 
-    def test_load_processes_events_until_loaded(
-        self, is_loaded_mock, time_mock
-    ):
+    def test_load_processes_events_until_loaded(self, is_loaded_mock, time_mock):
         is_loaded_mock.side_effect = [False, False, False, False, False, True]
         time_mock.time.side_effect = time.time
 
@@ -115,9 +109,7 @@ class LoadableTest(unittest.TestCase):
         with self.assertRaises(spotify.Error):
             foo.load()
 
-    def test_load_does_not_abort_on_is_loading_error(
-        self, is_loaded_mock, time_mock
-    ):
+    def test_load_does_not_abort_on_is_loading_error(self, is_loaded_mock, time_mock):
         is_loaded_mock.side_effect = [False, False, False, False, False, True]
         time_mock.time.side_effect = time.time
 

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -7,8 +7,8 @@ import tests
 from tests import mock
 
 
-@mock.patch('spotify.offline.lib', spec=spotify.lib)
-@mock.patch('spotify.session.lib', spec=spotify.lib)
+@mock.patch("spotify.offline.lib", spec=spotify.lib)
+@mock.patch("spotify.session.lib", spec=spotify.lib)
 class OfflineTest(unittest.TestCase):
     def tearDown(self):
         spotify._session_instance = None
@@ -70,7 +70,7 @@ class OfflineTest(unittest.TestCase):
 
 class OfflineSyncStatusTest(unittest.TestCase):
     def setUp(self):
-        self._sp_offline_sync_status = spotify.ffi.new('sp_offline_sync_status *')
+        self._sp_offline_sync_status = spotify.ffi.new("sp_offline_sync_status *")
         self._sp_offline_sync_status.queued_tracks = 5
         self._sp_offline_sync_status.done_tracks = 16
         self._sp_offline_sync_status.copied_tracks = 27

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -19,9 +19,7 @@ class OfflineTest(unittest.TestCase):
 
         result = session.offline.tracks_to_sync
 
-        lib_mock.sp_offline_tracks_to_sync.assert_called_with(
-            session._sp_session
-        )
+        lib_mock.sp_offline_tracks_to_sync.assert_called_with(session._sp_session)
         self.assertEqual(result, 17)
 
     def test_offline_num_playlists(self, session_lib_mock, lib_mock):
@@ -30,9 +28,7 @@ class OfflineTest(unittest.TestCase):
 
         result = session.offline.num_playlists
 
-        lib_mock.sp_offline_num_playlists.assert_called_with(
-            session._sp_session
-        )
+        lib_mock.sp_offline_num_playlists.assert_called_with(session._sp_session)
         self.assertEqual(result, 5)
 
     def test_offline_sync_status(self, session_lib_mock, lib_mock):
@@ -51,9 +47,7 @@ class OfflineTest(unittest.TestCase):
         self.assertIsInstance(result, spotify.OfflineSyncStatus)
         self.assertEqual(result.queued_tracks, 3)
 
-    def test_offline_sync_status_when_not_syncing(
-        self, session_lib_mock, lib_mock
-    ):
+    def test_offline_sync_status_when_not_syncing(self, session_lib_mock, lib_mock):
         lib_mock.sp_offline_sync_get_status.return_value = 0
         session = tests.create_real_session(session_lib_mock)
 
@@ -76,9 +70,7 @@ class OfflineTest(unittest.TestCase):
 
 class OfflineSyncStatusTest(unittest.TestCase):
     def setUp(self):
-        self._sp_offline_sync_status = spotify.ffi.new(
-            'sp_offline_sync_status *'
-        )
+        self._sp_offline_sync_status = spotify.ffi.new('sp_offline_sync_status *')
         self._sp_offline_sync_status.queued_tracks = 5
         self._sp_offline_sync_status.done_tracks = 16
         self._sp_offline_sync_status.copied_tracks = 27

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-
 import tests
 from tests import mock
 

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -13,9 +13,7 @@ class PlayerTest(unittest.TestCase):
     def tearDown(self):
         spotify._session_instance = None
 
-    def test_player_state_is_unloaded_initially(
-        self, session_lib_mock, lib_mock
-    ):
+    def test_player_state_is_unloaded_initially(self, session_lib_mock, lib_mock):
         session = tests.create_real_session(session_lib_mock)
 
         self.assertEqual(session.player.state, spotify.PlayerState.UNLOADED)
@@ -63,9 +61,7 @@ class PlayerTest(unittest.TestCase):
         self.assertEqual(session.player.state, player_state)
 
     def test_player_seek_fail_raises_error(self, session_lib_mock, lib_mock):
-        lib_mock.sp_session_player_seek.return_value = (
-            spotify.ErrorType.BAD_API_VERSION
-        )
+        lib_mock.sp_session_player_seek.return_value = spotify.ErrorType.BAD_API_VERSION
         session = tests.create_real_session(session_lib_mock)
         player_state = session.player.state
 
@@ -79,9 +75,7 @@ class PlayerTest(unittest.TestCase):
 
         session.player.play(True)
 
-        lib_mock.sp_session_player_play.assert_called_once_with(
-            session._sp_session, 1
-        )
+        lib_mock.sp_session_player_play.assert_called_once_with(session._sp_session, 1)
         self.assertEqual(session.player.state, spotify.PlayerState.PLAYING)
 
     def test_player_play_with_false_to_pause(self, session_lib_mock, lib_mock):
@@ -90,15 +84,11 @@ class PlayerTest(unittest.TestCase):
 
         session.player.play(False)
 
-        lib_mock.sp_session_player_play.assert_called_once_with(
-            session._sp_session, 0
-        )
+        lib_mock.sp_session_player_play.assert_called_once_with(session._sp_session, 0)
         self.assertEqual(session.player.state, spotify.PlayerState.PAUSED)
 
     def test_player_play_fail_raises_error(self, session_lib_mock, lib_mock):
-        lib_mock.sp_session_player_play.return_value = (
-            spotify.ErrorType.BAD_API_VERSION
-        )
+        lib_mock.sp_session_player_play.return_value = spotify.ErrorType.BAD_API_VERSION
         session = tests.create_real_session(session_lib_mock)
         player_state = session.player.state
 
@@ -112,9 +102,7 @@ class PlayerTest(unittest.TestCase):
 
         session.player.pause()
 
-        lib_mock.sp_session_player_play.assert_called_once_with(
-            session._sp_session, 0
-        )
+        lib_mock.sp_session_player_play.assert_called_once_with(session._sp_session, 0)
         self.assertEqual(session.player.state, spotify.PlayerState.PAUSED)
 
     def test_player_unload(self, session_lib_mock, lib_mock):
@@ -123,9 +111,7 @@ class PlayerTest(unittest.TestCase):
 
         session.player.unload()
 
-        lib_mock.sp_session_player_unload.assert_called_once_with(
-            session._sp_session
-        )
+        lib_mock.sp_session_player_unload.assert_called_once_with(session._sp_session)
         self.assertEqual(session.player.state, spotify.PlayerState.UNLOADED)
 
     def test_player_unload_fail_raises_error(self, session_lib_mock, lib_mock):
@@ -156,9 +142,7 @@ class PlayerTest(unittest.TestCase):
     def test_player_prefetch_fail_raises_error(
         self, track_lib_mock, session_lib_mock, lib_mock
     ):
-        lib_mock.sp_session_player_prefetch.return_value = (
-            spotify.ErrorType.NO_CACHE
-        )
+        lib_mock.sp_session_player_prefetch.return_value = spotify.ErrorType.NO_CACHE
         session = tests.create_real_session(session_lib_mock)
         sp_track = spotify.ffi.cast('sp_track *', 42)
         track = spotify.Track(session, sp_track=sp_track)

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -7,8 +7,8 @@ import tests
 from tests import mock
 
 
-@mock.patch('spotify.player.lib', spec=spotify.lib)
-@mock.patch('spotify.session.lib', spec=spotify.lib)
+@mock.patch("spotify.player.lib", spec=spotify.lib)
+@mock.patch("spotify.session.lib", spec=spotify.lib)
 class PlayerTest(unittest.TestCase):
     def tearDown(self):
         spotify._session_instance = None
@@ -18,11 +18,11 @@ class PlayerTest(unittest.TestCase):
 
         self.assertEqual(session.player.state, spotify.PlayerState.UNLOADED)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_player_load(self, track_lib_mock, session_lib_mock, lib_mock):
         lib_mock.sp_session_player_load.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(session_lib_mock)
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(session, sp_track=sp_track)
 
         session.player.load(track)
@@ -32,7 +32,7 @@ class PlayerTest(unittest.TestCase):
         )
         self.assertEqual(session.player.state, spotify.PlayerState.LOADED)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_player_load_fail_raises_error(
         self, track_lib_mock, session_lib_mock, lib_mock
     ):
@@ -41,7 +41,7 @@ class PlayerTest(unittest.TestCase):
         )
         session = tests.create_real_session(session_lib_mock)
         player_state = session.player.state
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(session, sp_track=sp_track)
 
         with self.assertRaises(spotify.Error):
@@ -125,11 +125,11 @@ class PlayerTest(unittest.TestCase):
             session.player.unload()
         self.assertEqual(session.player.state, player_state)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_player_prefetch(self, track_lib_mock, session_lib_mock, lib_mock):
         lib_mock.sp_session_player_prefetch.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(session_lib_mock)
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(session, sp_track=sp_track)
 
         session.player.prefetch(track)
@@ -138,13 +138,13 @@ class PlayerTest(unittest.TestCase):
             session._sp_session, sp_track
         )
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_player_prefetch_fail_raises_error(
         self, track_lib_mock, session_lib_mock, lib_mock
     ):
         lib_mock.sp_session_player_prefetch.return_value = spotify.ErrorType.NO_CACHE
         session = tests.create_real_session(session_lib_mock)
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(session, sp_track=sp_track)
 
         with self.assertRaises(spotify.Error):

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-
 import tests
 from tests import mock
 

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -249,9 +249,7 @@ class PlaylistTest(unittest.TestCase):
             [mock.call(3), mock.call(2)], any_order=False
         )
 
-    def test_tracks_setittem_with_slice_and_noniterable_value_fails(
-        self, lib_mock
-    ):
+    def test_tracks_setittem_with_slice_and_noniterable_value_fails(self, lib_mock):
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
@@ -260,9 +258,7 @@ class PlaylistTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             tracks[0:2] = mock.sentinel.track
 
-    def test_tracks_setitem_raises_index_error_on_negative_index(
-        self, lib_mock
-    ):
+    def test_tracks_setitem_raises_index_error_on_negative_index(self, lib_mock):
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
@@ -271,9 +267,7 @@ class PlaylistTest(unittest.TestCase):
         with self.assertRaises(IndexError):
             tracks[-1] = None
 
-    def test_tracks_setitem_raises_index_error_on_too_high_index(
-        self, lib_mock
-    ):
+    def test_tracks_setitem_raises_index_error_on_too_high_index(self, lib_mock):
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
@@ -282,9 +276,7 @@ class PlaylistTest(unittest.TestCase):
         with self.assertRaises(IndexError):
             tracks[1] = None
 
-    def test_tracks_setitem_raises_type_error_on_non_integral_index(
-        self, lib_mock
-    ):
+    def test_tracks_setitem_raises_type_error_on_non_integral_index(self, lib_mock):
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
@@ -294,9 +286,7 @@ class PlaylistTest(unittest.TestCase):
             tracks['abc'] = None
 
     def test_tracks_delitem(self, lib_mock):
-        lib_mock.sp_playlist_remove_tracks.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_playlist_remove_tracks.return_value = int(spotify.ErrorType.OK)
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
@@ -304,14 +294,10 @@ class PlaylistTest(unittest.TestCase):
 
         del tracks[3]
 
-        lib_mock.sp_playlist_remove_tracks.assert_called_with(
-            sp_playlist, [3], 1
-        )
+        lib_mock.sp_playlist_remove_tracks.assert_called_with(sp_playlist, [3], 1)
 
     def test_tracks_delitem_with_slice(self, lib_mock):
-        lib_mock.sp_playlist_remove_tracks.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_playlist_remove_tracks.return_value = int(spotify.ErrorType.OK)
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
@@ -325,12 +311,8 @@ class PlaylistTest(unittest.TestCase):
             any_order=False,
         )
 
-    def test_tracks_delitem_raises_index_error_on_negative_index(
-        self, lib_mock
-    ):
-        lib_mock.sp_playlist_remove_tracks.return_value = int(
-            spotify.ErrorType.OK
-        )
+    def test_tracks_delitem_raises_index_error_on_negative_index(self, lib_mock):
+        lib_mock.sp_playlist_remove_tracks.return_value = int(spotify.ErrorType.OK)
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
@@ -339,12 +321,8 @@ class PlaylistTest(unittest.TestCase):
         with self.assertRaises(IndexError):
             del tracks[-1]
 
-    def test_tracks_delitem_raises_index_error_on_too_high_index(
-        self, lib_mock
-    ):
-        lib_mock.sp_playlist_remove_tracks.return_value = int(
-            spotify.ErrorType.OK
-        )
+    def test_tracks_delitem_raises_index_error_on_too_high_index(self, lib_mock):
+        lib_mock.sp_playlist_remove_tracks.return_value = int(spotify.ErrorType.OK)
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
@@ -353,12 +331,8 @@ class PlaylistTest(unittest.TestCase):
         with self.assertRaises(IndexError):
             del tracks[1]
 
-    def test_tracks_delitem_raises_type_error_on_non_integral_index(
-        self, lib_mock
-    ):
-        lib_mock.sp_playlist_remove_tracks.return_value = int(
-            spotify.ErrorType.OK
-        )
+    def test_tracks_delitem_raises_type_error_on_non_integral_index(self, lib_mock):
+        lib_mock.sp_playlist_remove_tracks.return_value = int(spotify.ErrorType.OK)
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
@@ -386,17 +360,13 @@ class PlaylistTest(unittest.TestCase):
 
         # Created a Playlist with a ref to sp_playlist
         self.assertEqual(lib_mock.sp_playlist_add_ref.call_count, 1)
-        self.assertEqual(
-            playlist_track_lib_mock.sp_playlist_add_ref.call_count, 0
-        )
+        self.assertEqual(playlist_track_lib_mock.sp_playlist_add_ref.call_count, 0)
 
         result = playlist.tracks_with_metadata
 
         # Created a Sequence with a ref to sp_playlist
         self.assertEqual(lib_mock.sp_playlist_add_ref.call_count, 2)
-        self.assertEqual(
-            playlist_track_lib_mock.sp_playlist_add_ref.call_count, 0
-        )
+        self.assertEqual(playlist_track_lib_mock.sp_playlist_add_ref.call_count, 0)
 
         self.assertEqual(len(result), 1)
         lib_mock.sp_playlist_num_tracks.assert_called_with(sp_playlist)
@@ -406,9 +376,7 @@ class PlaylistTest(unittest.TestCase):
 
         # Created a PlaylistTrack with a ref to sp_playlist
         self.assertEqual(lib_mock.sp_playlist_add_ref.call_count, 2)
-        self.assertEqual(
-            playlist_track_lib_mock.sp_playlist_add_ref.call_count, 1
-        )
+        self.assertEqual(playlist_track_lib_mock.sp_playlist_add_ref.call_count, 1)
 
     def test_tracks_with_metadata_if_no_tracks(self, lib_mock):
         lib_mock.sp_playlist_num_tracks.return_value = 0
@@ -510,17 +478,13 @@ class PlaylistTest(unittest.TestCase):
         self.assertTrue(result)
 
     def test_set_collaborative(self, lib_mock):
-        lib_mock.sp_playlist_set_collaborative.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_playlist_set_collaborative.return_value = int(spotify.ErrorType.OK)
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         playlist.collaborative = False
 
-        lib_mock.sp_playlist_set_collaborative.assert_called_with(
-            sp_playlist, 0
-        )
+        lib_mock.sp_playlist_set_collaborative.assert_called_with(sp_playlist, 0)
 
     def test_set_collaborative_fails_if_error(self, lib_mock):
         lib_mock.sp_playlist_set_collaborative.return_value = int(
@@ -541,9 +505,7 @@ class PlaylistTest(unittest.TestCase):
 
         playlist.set_autolink_tracks(True)
 
-        lib_mock.sp_playlist_set_autolink_tracks.assert_called_with(
-            sp_playlist, 1
-        )
+        lib_mock.sp_playlist_set_autolink_tracks.assert_called_with(sp_playlist, 1)
 
     def test_set_autolink_tracks_fails_if_error(self, lib_mock):
         lib_mock.sp_playlist_set_autolink_tracks.return_value = int(
@@ -598,9 +560,7 @@ class PlaylistTest(unittest.TestCase):
 
         self.assertIs(result, mock.sentinel.image)
         lib_mock.sp_playlist_get_image.assert_called_with(sp_playlist, mock.ANY)
-        lib_mock.sp_image_create.assert_called_with(
-            self.session._sp_session, mock.ANY
-        )
+        lib_mock.sp_image_create.assert_called_with(self.session._sp_session, mock.ANY)
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_image_create.call_args[0][1]),
             b'image-id',
@@ -693,9 +653,7 @@ class PlaylistTest(unittest.TestCase):
 
     @mock.patch('spotify.track.lib', spec=spotify.lib)
     def test_remove_tracks(self, track_lib_mock, lib_mock):
-        lib_mock.sp_playlist_remove_tracks.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_playlist_remove_tracks.return_value = int(spotify.ErrorType.OK)
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         index1 = 13
@@ -703,45 +661,31 @@ class PlaylistTest(unittest.TestCase):
 
         playlist.remove_tracks([index1, index2])
 
-        lib_mock.sp_playlist_remove_tracks.assert_called_with(
-            sp_playlist, mock.ANY, 2
-        )
-        self.assertIn(
-            index1, lib_mock.sp_playlist_remove_tracks.call_args[0][1]
-        )
-        self.assertIn(
-            index2, lib_mock.sp_playlist_remove_tracks.call_args[0][1]
-        )
+        lib_mock.sp_playlist_remove_tracks.assert_called_with(sp_playlist, mock.ANY, 2)
+        self.assertIn(index1, lib_mock.sp_playlist_remove_tracks.call_args[0][1])
+        self.assertIn(index2, lib_mock.sp_playlist_remove_tracks.call_args[0][1])
 
     @mock.patch('spotify.track.lib', spec=spotify.lib)
     def test_remove_tracks_with_a_single_track(self, track_lib_mock, lib_mock):
-        lib_mock.sp_playlist_remove_tracks.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_playlist_remove_tracks.return_value = int(spotify.ErrorType.OK)
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         index = 17
 
         playlist.remove_tracks(index)
 
-        lib_mock.sp_playlist_remove_tracks.assert_called_with(
-            sp_playlist, [index], 1
-        )
+        lib_mock.sp_playlist_remove_tracks.assert_called_with(sp_playlist, [index], 1)
 
     @mock.patch('spotify.track.lib', spec=spotify.lib)
     def test_remove_tracks_with_duplicates(self, track_lib_mock, lib_mock):
-        lib_mock.sp_playlist_remove_tracks.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_playlist_remove_tracks.return_value = int(spotify.ErrorType.OK)
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         index = 17
 
         playlist.remove_tracks([index, index])
 
-        lib_mock.sp_playlist_remove_tracks.assert_called_with(
-            sp_playlist, [index], 1
-        )
+        lib_mock.sp_playlist_remove_tracks.assert_called_with(sp_playlist, [index], 1)
 
     @mock.patch('spotify.track.lib', spec=spotify.lib)
     def test_remove_tracks_fails_if_error(self, track_lib_mock, lib_mock):
@@ -757,9 +701,7 @@ class PlaylistTest(unittest.TestCase):
 
     @mock.patch('spotify.track.lib', spec=spotify.lib)
     def test_reorder_tracks(self, track_lib_mock, lib_mock):
-        lib_mock.sp_playlist_reorder_tracks.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_playlist_reorder_tracks.return_value = int(spotify.ErrorType.OK)
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         position1 = 13
@@ -770,18 +712,12 @@ class PlaylistTest(unittest.TestCase):
         lib_mock.sp_playlist_reorder_tracks.assert_called_with(
             sp_playlist, mock.ANY, 2, 17
         )
-        self.assertIn(
-            position1, lib_mock.sp_playlist_reorder_tracks.call_args[0][1]
-        )
-        self.assertIn(
-            position2, lib_mock.sp_playlist_reorder_tracks.call_args[0][1]
-        )
+        self.assertIn(position1, lib_mock.sp_playlist_reorder_tracks.call_args[0][1])
+        self.assertIn(position2, lib_mock.sp_playlist_reorder_tracks.call_args[0][1])
 
     @mock.patch('spotify.track.lib', spec=spotify.lib)
     def test_reorder_tracks_with_a_single_track(self, track_lib_mock, lib_mock):
-        lib_mock.sp_playlist_reorder_tracks.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_playlist_reorder_tracks.return_value = int(spotify.ErrorType.OK)
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         position = 13
@@ -794,9 +730,7 @@ class PlaylistTest(unittest.TestCase):
 
     @mock.patch('spotify.track.lib', spec=spotify.lib)
     def test_reorder_tracks_with_duplicates(self, track_lib_mock, lib_mock):
-        lib_mock.sp_playlist_reorder_tracks.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_playlist_reorder_tracks.return_value = int(spotify.ErrorType.OK)
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         position = 13
@@ -846,9 +780,7 @@ class PlaylistTest(unittest.TestCase):
         self.assertEqual(result, ['alice'])
 
     def test_update_subscribers(self, lib_mock):
-        lib_mock.sp_playlist_update_subscribers.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_playlist_update_subscribers.return_value = int(spotify.ErrorType.OK)
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
@@ -902,9 +834,7 @@ class PlaylistTest(unittest.TestCase):
             playlist.set_in_ram(False)
 
     def test_set_offline_mode(self, lib_mock):
-        lib_mock.sp_playlist_set_offline_mode.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_playlist_set_offline_mode.return_value = int(spotify.ErrorType.OK)
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
@@ -972,9 +902,7 @@ class PlaylistTest(unittest.TestCase):
 
         result = playlist.link
 
-        link_mock.assert_called_once_with(
-            self.session, sp_link=sp_link, add_ref=False
-        )
+        link_mock.assert_called_once_with(self.session, sp_link=sp_link, add_ref=False)
         self.assertEqual(result, mock.sentinel.link)
 
     @mock.patch('spotify.Link', spec=spotify.Link)
@@ -991,9 +919,7 @@ class PlaylistTest(unittest.TestCase):
         self.assertEqual(lib_mock.sp_link_create_from_playlist.call_count, 0)
 
     @mock.patch('spotify.Link', spec=spotify.Link)
-    def test_link_may_fail_if_playlist_has_not_been_in_ram(
-        self, link_mock, lib_mock
-    ):
+    def test_link_may_fail_if_playlist_has_not_been_in_ram(self, link_mock, lib_mock):
         lib_mock.sp_playlist_is_loaded.return_value = 1
         lib_mock.sp_link_create_from_playlist.return_value = spotify.ffi.NULL
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
@@ -1053,9 +979,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
     def test_tracks_added_callback(self, track_lib_mock, lib_mock):
         callback = mock.Mock()
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
-        playlist = spotify.Playlist._cached(
-            self.session, sp_playlist=sp_playlist
-        )
+        playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.TRACKS_ADDED, callback)
         sp_tracks = [
             spotify.ffi.cast('sp_track *', 43),
@@ -1084,9 +1008,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
     def test_tracks_removed_callback(self, lib_mock):
         callback = mock.Mock()
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
-        playlist = spotify.Playlist._cached(
-            self.session, sp_playlist=sp_playlist
-        )
+        playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.TRACKS_REMOVED, callback)
         track_numbers = [43, 44, 45]
 
@@ -1102,9 +1024,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
     def test_tracks_moved_callback(self, lib_mock):
         callback = mock.Mock()
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
-        playlist = spotify.Playlist._cached(
-            self.session, sp_playlist=sp_playlist
-        )
+        playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.TRACKS_MOVED, callback)
         track_numbers = [43, 44, 45]
         index = 7
@@ -1125,9 +1045,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
     def test_playlist_renamed_callback(self, lib_mock):
         callback = mock.Mock()
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
-        playlist = spotify.Playlist._cached(
-            self.session, sp_playlist=sp_playlist
-        )
+        playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.PLAYLIST_RENAMED, callback)
 
         _PlaylistCallbacks.playlist_renamed(sp_playlist, spotify.ffi.NULL)
@@ -1137,9 +1055,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
     def test_playlist_state_changed_callback(self, lib_mock):
         callback = mock.Mock()
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
-        playlist = spotify.Playlist._cached(
-            self.session, sp_playlist=sp_playlist
-        )
+        playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.PLAYLIST_STATE_CHANGED, callback)
 
         _PlaylistCallbacks.playlist_state_changed(sp_playlist, spotify.ffi.NULL)
@@ -1149,9 +1065,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
     def test_playlist_update_in_progress_callback(self, lib_mock):
         callback = mock.Mock()
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
-        playlist = spotify.Playlist._cached(
-            self.session, sp_playlist=sp_playlist
-        )
+        playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.PLAYLIST_UPDATE_IN_PROGRESS, callback)
         done = True
 
@@ -1164,14 +1078,10 @@ class PlaylistCallbacksTest(unittest.TestCase):
     def test_playlist_metadata_updated_callback(self, lib_mock):
         callback = mock.Mock()
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
-        playlist = spotify.Playlist._cached(
-            self.session, sp_playlist=sp_playlist
-        )
+        playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.PLAYLIST_METADATA_UPDATED, callback)
 
-        _PlaylistCallbacks.playlist_metadata_updated(
-            sp_playlist, spotify.ffi.NULL
-        )
+        _PlaylistCallbacks.playlist_metadata_updated(sp_playlist, spotify.ffi.NULL)
 
         callback.assert_called_once_with(playlist)
 
@@ -1179,9 +1089,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
     def test_track_created_changed_callback(self, user_lib_mock, lib_mock):
         callback = mock.Mock()
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
-        playlist = spotify.Playlist._cached(
-            self.session, sp_playlist=sp_playlist
-        )
+        playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.TRACK_CREATED_CHANGED, callback)
         index = 7
         sp_user = spotify.ffi.cast('sp_user *', 43)
@@ -1200,9 +1108,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
     def test_track_seen_changed_callback(self, lib_mock):
         callback = mock.Mock()
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
-        playlist = spotify.Playlist._cached(
-            self.session, sp_playlist=sp_playlist
-        )
+        playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.TRACK_SEEN_CHANGED, callback)
         index = 7
         seen = True
@@ -1216,16 +1122,12 @@ class PlaylistCallbacksTest(unittest.TestCase):
     def test_description_changed_callback(self, lib_mock):
         callback = mock.Mock()
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
-        playlist = spotify.Playlist._cached(
-            self.session, sp_playlist=sp_playlist
-        )
+        playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.DESCRIPTION_CHANGED, callback)
         description = 'foo bar æøå'
         desc = spotify.ffi.new('char[]', description.encode('utf-8'))
 
-        _PlaylistCallbacks.description_changed(
-            sp_playlist, desc, spotify.ffi.NULL
-        )
+        _PlaylistCallbacks.description_changed(sp_playlist, desc, spotify.ffi.NULL)
 
         callback.assert_called_once_with(playlist, description)
 
@@ -1233,9 +1135,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
     def test_image_changed_callback(self, image_lib_mock, lib_mock):
         callback = mock.Mock()
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
-        playlist = spotify.Playlist._cached(
-            self.session, sp_playlist=sp_playlist
-        )
+        playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.IMAGE_CHANGED, callback)
         image_id = spotify.ffi.new('char[]', b'image-id')
         sp_image = spotify.ffi.cast('sp_image *', 43)
@@ -1244,9 +1144,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
             spotify.ErrorType.OK
         )
 
-        _PlaylistCallbacks.image_changed(
-            sp_playlist, image_id, spotify.ffi.NULL
-        )
+        _PlaylistCallbacks.image_changed(sp_playlist, image_id, spotify.ffi.NULL)
 
         callback.assert_called_once_with(playlist, mock.ANY)
         image = callback.call_args[0][1]
@@ -1260,9 +1158,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
     def test_track_message_changed_callback(self, lib_mock):
         callback = mock.Mock()
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
-        playlist = spotify.Playlist._cached(
-            self.session, sp_playlist=sp_playlist
-        )
+        playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.TRACK_MESSAGE_CHANGED, callback)
         index = 7
         message = 'foo bar æøå'
@@ -1277,9 +1173,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
     def test_subscribers_changed_callback(self, lib_mock):
         callback = mock.Mock()
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
-        playlist = spotify.Playlist._cached(
-            self.session, sp_playlist=sp_playlist
-        )
+        playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.SUBSCRIBERS_CHANGED, callback)
 
         _PlaylistCallbacks.subscribers_changed(sp_playlist, spotify.ffi.NULL)

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -5,10 +5,9 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
+import tests
 from spotify import compat
 from spotify.playlist import _PlaylistCallbacks
-
-import tests
 from tests import mock
 
 

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -11,7 +11,7 @@ from spotify.playlist import _PlaylistCallbacks
 from tests import mock
 
 
-@mock.patch('spotify.playlist.lib', spec=spotify.lib)
+@mock.patch("spotify.playlist.lib", spec=spotify.lib)
 class PlaylistTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
@@ -20,12 +20,12 @@ class PlaylistTest(unittest.TestCase):
         with self.assertRaises(AssertionError):
             spotify.Playlist(self.session)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_create_from_uri(self, link_mock, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         link_instance_mock = link_mock.return_value
         link_instance_mock._as_sp_playlist.return_value = sp_playlist
-        uri = 'spotify:playlist:foo'
+        uri = "spotify:playlist:foo"
 
         result = spotify.Playlist(self.session, uri=uri)
 
@@ -35,28 +35,28 @@ class PlaylistTest(unittest.TestCase):
         self.assertEqual(lib_mock.sp_playlist_add_ref.call_count, 0)
         self.assertEqual(result._sp_playlist, sp_playlist)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_create_from_uri_is_cached(self, link_mock, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         link_instance_mock = link_mock.return_value
         link_instance_mock._as_sp_playlist.return_value = sp_playlist
-        uri = 'spotify:playlist:foo'
+        uri = "spotify:playlist:foo"
 
         result = spotify.Playlist(self.session, uri=uri)
 
         self.assertEqual(self.session._cache[sp_playlist], result)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_create_from_uri_fail_raises_error(self, link_mock, lib_mock):
         link_instance_mock = link_mock.return_value
         link_instance_mock._as_sp_playlist.return_value = None
-        uri = 'spotify:playlist:foo'
+        uri = "spotify:playlist:foo"
 
         with self.assertRaises(spotify.Error):
             spotify.Playlist(self.session, uri=uri)
 
     def test_life_cycle(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
 
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         sp_playlist = playlist._sp_playlist
@@ -84,7 +84,7 @@ class PlaylistTest(unittest.TestCase):
         # lib_mock.sp_playlist_release.assert_called_with(sp_playlist)
 
     def test_cached_playlist(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
 
         result1 = spotify.Playlist._cached(self.session, sp_playlist)
         result2 = spotify.Playlist._cached(self.session, sp_playlist)
@@ -92,56 +92,56 @@ class PlaylistTest(unittest.TestCase):
         self.assertIsInstance(result1, spotify.Playlist)
         self.assertIs(result1, result2)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_repr(self, link_mock, lib_mock):
         lib_mock.sp_playlist_is_loaded.return_value = 1
         link_instance_mock = link_mock.return_value
-        link_instance_mock.uri = 'foo'
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        link_instance_mock.uri = "foo"
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = repr(playlist)
 
-        self.assertEqual(result, 'Playlist(%r)' % 'foo')
+        self.assertEqual(result, "Playlist(%r)" % "foo")
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_repr_if_unloaded(self, link_mock, lib_mock):
         lib_mock.sp_playlist_is_loaded.return_value = 0
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = repr(playlist)
 
-        self.assertEqual(result, 'Playlist(<not loaded>)')
+        self.assertEqual(result, "Playlist(<not loaded>)")
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_repr_if_link_creation_fails(self, link_mock, lib_mock):
         lib_mock.sp_playlist_is_loaded.return_value = 1
-        link_mock.side_effect = spotify.Error('error message')
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        link_mock.side_effect = spotify.Error("error message")
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = repr(playlist)
 
-        self.assertEqual(result, 'Playlist(<error: error message>)')
+        self.assertEqual(result, "Playlist(<error: error message>)")
 
     def test_eq(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist1 = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         playlist2 = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         self.assertTrue(playlist1 == playlist2)
-        self.assertFalse(playlist1 == 'foo')
+        self.assertFalse(playlist1 == "foo")
 
     def test_ne(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist1 = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         playlist2 = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         self.assertFalse(playlist1 != playlist2)
 
     def test_hash(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist1 = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         playlist2 = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
@@ -149,7 +149,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_is_loaded(self, lib_mock):
         lib_mock.sp_playlist_is_loaded.return_value = 1
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.is_loaded
@@ -157,21 +157,21 @@ class PlaylistTest(unittest.TestCase):
         lib_mock.sp_playlist_is_loaded.assert_called_once_with(sp_playlist)
         self.assertTrue(result)
 
-    @mock.patch('spotify.utils.load')
+    @mock.patch("spotify.utils.load")
     def test_load(self, load_mock, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         playlist.load(10)
 
         load_mock.assert_called_with(self.session, playlist, timeout=10)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_tracks(self, track_lib_mock, lib_mock):
-        sp_track = spotify.ffi.cast('sp_track *', 43)
+        sp_track = spotify.ffi.cast("sp_track *", 43)
         lib_mock.sp_playlist_num_tracks.return_value = 1
         lib_mock.sp_playlist_track.return_value = sp_track
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         self.assertEqual(lib_mock.sp_playlist_add_ref.call_count, 1)
@@ -190,7 +190,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_tracks_if_no_tracks(self, lib_mock):
         lib_mock.sp_playlist_num_tracks.return_value = 0
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.tracks
@@ -201,7 +201,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_tracks_if_unloaded(self, lib_mock):
         lib_mock.sp_playlist_is_loaded.return_value = 0
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.tracks
@@ -210,13 +210,13 @@ class PlaylistTest(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
     def test_tracks_is_a_mutable_sequence(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         self.assertIsInstance(playlist.tracks, compat.MutableSequence)
 
     def test_tracks_setitem(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
         tracks.__len__ = mock.Mock(return_value=5)
@@ -229,7 +229,7 @@ class PlaylistTest(unittest.TestCase):
         playlist.remove_tracks.assert_called_with(1)
 
     def test_tracks_setitem_with_slice(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
         tracks.__len__ = mock.Mock(return_value=5)
@@ -250,7 +250,7 @@ class PlaylistTest(unittest.TestCase):
         )
 
     def test_tracks_setittem_with_slice_and_noniterable_value_fails(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
         tracks.__len__ = mock.Mock(return_value=5)
@@ -259,7 +259,7 @@ class PlaylistTest(unittest.TestCase):
             tracks[0:2] = mock.sentinel.track
 
     def test_tracks_setitem_raises_index_error_on_negative_index(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
         tracks.__len__ = mock.Mock(return_value=5)
@@ -268,7 +268,7 @@ class PlaylistTest(unittest.TestCase):
             tracks[-1] = None
 
     def test_tracks_setitem_raises_index_error_on_too_high_index(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
         tracks.__len__ = mock.Mock(return_value=1)
@@ -277,17 +277,17 @@ class PlaylistTest(unittest.TestCase):
             tracks[1] = None
 
     def test_tracks_setitem_raises_type_error_on_non_integral_index(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
         tracks.__len__ = mock.Mock(return_value=1)
 
         with self.assertRaises(TypeError):
-            tracks['abc'] = None
+            tracks["abc"] = None
 
     def test_tracks_delitem(self, lib_mock):
         lib_mock.sp_playlist_remove_tracks.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
         tracks.__len__ = mock.Mock(return_value=4)
@@ -298,7 +298,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_tracks_delitem_with_slice(self, lib_mock):
         lib_mock.sp_playlist_remove_tracks.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
         tracks.__len__ = mock.Mock(return_value=3)
@@ -313,7 +313,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_tracks_delitem_raises_index_error_on_negative_index(self, lib_mock):
         lib_mock.sp_playlist_remove_tracks.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
         tracks.__len__ = mock.Mock(return_value=1)
@@ -323,7 +323,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_tracks_delitem_raises_index_error_on_too_high_index(self, lib_mock):
         lib_mock.sp_playlist_remove_tracks.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
         tracks.__len__ = mock.Mock(return_value=1)
@@ -333,16 +333,16 @@ class PlaylistTest(unittest.TestCase):
 
     def test_tracks_delitem_raises_type_error_on_non_integral_index(self, lib_mock):
         lib_mock.sp_playlist_remove_tracks.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
         tracks.__len__ = mock.Mock(return_value=1)
 
         with self.assertRaises(TypeError):
-            del tracks['abc']
+            del tracks["abc"]
 
     def test_tracks_insert(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         tracks = playlist.tracks
         tracks.__len__ = mock.Mock(return_value=5)
@@ -352,10 +352,10 @@ class PlaylistTest(unittest.TestCase):
 
         playlist.add_tracks.assert_called_with(mock.sentinel.track, index=3)
 
-    @mock.patch('spotify.playlist_track.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist_track.lib", spec=spotify.lib)
     def test_tracks_with_metadata(self, playlist_track_lib_mock, lib_mock):
         lib_mock.sp_playlist_num_tracks.return_value = 1
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         # Created a Playlist with a ref to sp_playlist
@@ -380,7 +380,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_tracks_with_metadata_if_no_tracks(self, lib_mock):
         lib_mock.sp_playlist_num_tracks.return_value = 0
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.tracks_with_metadata
@@ -391,7 +391,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_tracks_with_metadata_if_unloaded(self, lib_mock):
         lib_mock.sp_playlist_is_loaded.return_value = 0
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.tracks_with_metadata
@@ -401,19 +401,19 @@ class PlaylistTest(unittest.TestCase):
 
     def test_name(self, lib_mock):
         lib_mock.sp_playlist_name.return_value = spotify.ffi.new(
-            'char[]', b'Foo Bar Baz'
+            "char[]", b"Foo Bar Baz"
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.name
 
         lib_mock.sp_playlist_name.assert_called_once_with(sp_playlist)
-        self.assertEqual(result, 'Foo Bar Baz')
+        self.assertEqual(result, "Foo Bar Baz")
 
     def test_name_is_none_if_unloaded(self, lib_mock):
-        lib_mock.sp_playlist_name.return_value = spotify.ffi.new('char[]', b'')
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        lib_mock.sp_playlist_name.return_value = spotify.ffi.new("char[]", b"")
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.name
@@ -423,41 +423,41 @@ class PlaylistTest(unittest.TestCase):
 
     def test_rename(self, lib_mock):
         lib_mock.sp_playlist_rename.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
-        playlist.rename('Quux')
+        playlist.rename("Quux")
 
         lib_mock.sp_playlist_rename.assert_called_with(sp_playlist, mock.ANY)
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_playlist_rename.call_args[0][1]),
-            b'Quux',
+            b"Quux",
         )
 
     def test_rename_fails_if_error(self, lib_mock):
         lib_mock.sp_playlist_rename.return_value = int(
             spotify.ErrorType.BAD_API_VERSION
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         with self.assertRaises(spotify.Error):
-            playlist.rename('Quux')
+            playlist.rename("Quux")
 
     def test_name_setter(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         playlist.rename = mock.Mock()
 
-        playlist.name = 'Quux'
+        playlist.name = "Quux"
 
-        playlist.rename.assert_called_with('Quux')
+        playlist.rename.assert_called_with("Quux")
 
-    @mock.patch('spotify.user.lib', spec=spotify.lib)
+    @mock.patch("spotify.user.lib", spec=spotify.lib)
     def test_owner(self, user_lib_mock, lib_mock):
-        sp_user = spotify.ffi.cast('sp_user *', 43)
+        sp_user = spotify.ffi.cast("sp_user *", 43)
         lib_mock.sp_playlist_owner.return_value = sp_user
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.owner
@@ -469,7 +469,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_is_collaborative(self, lib_mock):
         lib_mock.sp_playlist_is_collaborative.return_value = 1
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.collaborative
@@ -479,7 +479,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_set_collaborative(self, lib_mock):
         lib_mock.sp_playlist_set_collaborative.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         playlist.collaborative = False
@@ -490,7 +490,7 @@ class PlaylistTest(unittest.TestCase):
         lib_mock.sp_playlist_set_collaborative.return_value = int(
             spotify.ErrorType.BAD_API_VERSION
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         with self.assertRaises(spotify.Error):
@@ -500,7 +500,7 @@ class PlaylistTest(unittest.TestCase):
         lib_mock.sp_playlist_set_autolink_tracks.return_value = int(
             spotify.ErrorType.OK
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         playlist.set_autolink_tracks(True)
@@ -511,7 +511,7 @@ class PlaylistTest(unittest.TestCase):
         lib_mock.sp_playlist_set_autolink_tracks.return_value = int(
             spotify.ErrorType.BAD_API_VERSION
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         with self.assertRaises(spotify.Error):
@@ -519,19 +519,19 @@ class PlaylistTest(unittest.TestCase):
 
     def test_description(self, lib_mock):
         lib_mock.sp_playlist_get_description.return_value = spotify.ffi.new(
-            'char[]', b'Lorem ipsum'
+            "char[]", b"Lorem ipsum"
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.description
 
         lib_mock.sp_playlist_get_description.assert_called_with(sp_playlist)
-        self.assertEqual(result, 'Lorem ipsum')
+        self.assertEqual(result, "Lorem ipsum")
 
     def test_description_is_none_if_unset(self, lib_mock):
         lib_mock.sp_playlist_get_description.return_value = spotify.ffi.NULL
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.description
@@ -539,9 +539,9 @@ class PlaylistTest(unittest.TestCase):
         lib_mock.sp_playlist_get_description.assert_called_with(sp_playlist)
         self.assertIsNone(result)
 
-    @mock.patch('spotify.Image', spec=spotify.Image)
+    @mock.patch("spotify.Image", spec=spotify.Image)
     def test_image(self, image_mock, lib_mock):
-        image_id = b'image-id'
+        image_id = b"image-id"
 
         def func(sp_playlist, sp_image_id):
             buf = spotify.ffi.buffer(sp_image_id)
@@ -549,9 +549,9 @@ class PlaylistTest(unittest.TestCase):
             return 1
 
         lib_mock.sp_playlist_get_image.side_effect = func
-        sp_image = spotify.ffi.cast('sp_image *', 43)
+        sp_image = spotify.ffi.cast("sp_image *", 43)
         lib_mock.sp_image_create.return_value = sp_image
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         image_mock.return_value = mock.sentinel.image
         callback = mock.Mock()
@@ -563,7 +563,7 @@ class PlaylistTest(unittest.TestCase):
         lib_mock.sp_image_create.assert_called_with(self.session._sp_session, mock.ANY)
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_image_create.call_args[0][1]),
-            b'image-id',
+            b"image-id",
         )
 
         # Since we *created* the sp_image, we already have a refcount of 1 and
@@ -575,7 +575,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_image_is_none_if_no_image(self, lib_mock):
         lib_mock.sp_playlist_get_image.return_value = 0
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.image()
@@ -585,7 +585,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_has_pending_changes(self, lib_mock):
         lib_mock.sp_playlist_has_pending_changes.return_value = 1
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.has_pending_changes
@@ -593,14 +593,14 @@ class PlaylistTest(unittest.TestCase):
         lib_mock.sp_playlist_has_pending_changes.assert_called_with(sp_playlist)
         self.assertTrue(result)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_add_tracks(self, track_lib_mock, lib_mock):
         lib_mock.sp_playlist_add_tracks.return_value = int(spotify.ErrorType.OK)
-        sp_track1 = spotify.ffi.new('int * ')
+        sp_track1 = spotify.ffi.new("int * ")
         track1 = spotify.Track(self.session, sp_track=sp_track1)
-        sp_track2 = spotify.ffi.new('int * ')
+        sp_track2 = spotify.ffi.new("int * ")
         track2 = spotify.Track(self.session, sp_track=sp_track2)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         playlist.add_tracks([track1, track2], index=4)
@@ -609,15 +609,15 @@ class PlaylistTest(unittest.TestCase):
             sp_playlist, [sp_track1, sp_track2], 2, 4, self.session._sp_session
         )
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_add_tracks_without_index(self, track_lib_mock, lib_mock):
         lib_mock.sp_playlist_add_tracks.return_value = int(spotify.ErrorType.OK)
         lib_mock.sp_playlist_num_tracks.return_value = 10
-        sp_track1 = spotify.ffi.new('int * ')
+        sp_track1 = spotify.ffi.new("int * ")
         track1 = spotify.Track(self.session, sp_track=sp_track1)
-        sp_track2 = spotify.ffi.new('int * ')
+        sp_track2 = spotify.ffi.new("int * ")
         track2 = spotify.Track(self.session, sp_track=sp_track2)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         playlist.add_tracks([track1, track2])
@@ -626,12 +626,12 @@ class PlaylistTest(unittest.TestCase):
             sp_playlist, [sp_track1, sp_track2], 2, 10, self.session._sp_session
         )
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_add_tracks_with_a_single_track(self, track_lib_mock, lib_mock):
         lib_mock.sp_playlist_add_tracks.return_value = int(spotify.ErrorType.OK)
-        sp_track = spotify.ffi.new('int * ')
+        sp_track = spotify.ffi.new("int * ")
         track = spotify.Track(self.session, sp_track=sp_track)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         playlist.add_tracks(track, index=7)
@@ -645,16 +645,16 @@ class PlaylistTest(unittest.TestCase):
             spotify.ErrorType.PERMISSION_DENIED
         )
         lib_mock.sp_playlist_num_tracks.return_value = 0
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         with self.assertRaises(spotify.Error):
             playlist.add_tracks([])
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_remove_tracks(self, track_lib_mock, lib_mock):
         lib_mock.sp_playlist_remove_tracks.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         index1 = 13
         index2 = 17
@@ -665,10 +665,10 @@ class PlaylistTest(unittest.TestCase):
         self.assertIn(index1, lib_mock.sp_playlist_remove_tracks.call_args[0][1])
         self.assertIn(index2, lib_mock.sp_playlist_remove_tracks.call_args[0][1])
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_remove_tracks_with_a_single_track(self, track_lib_mock, lib_mock):
         lib_mock.sp_playlist_remove_tracks.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         index = 17
 
@@ -676,10 +676,10 @@ class PlaylistTest(unittest.TestCase):
 
         lib_mock.sp_playlist_remove_tracks.assert_called_with(sp_playlist, [index], 1)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_remove_tracks_with_duplicates(self, track_lib_mock, lib_mock):
         lib_mock.sp_playlist_remove_tracks.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         index = 17
 
@@ -687,22 +687,22 @@ class PlaylistTest(unittest.TestCase):
 
         lib_mock.sp_playlist_remove_tracks.assert_called_with(sp_playlist, [index], 1)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_remove_tracks_fails_if_error(self, track_lib_mock, lib_mock):
         lib_mock.sp_playlist_remove_tracks.return_value = int(
             spotify.ErrorType.PERMISSION_DENIED
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         index = 17
 
         with self.assertRaises(spotify.Error):
             playlist.remove_tracks(index)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_reorder_tracks(self, track_lib_mock, lib_mock):
         lib_mock.sp_playlist_reorder_tracks.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         position1 = 13
         position2 = 17
@@ -715,10 +715,10 @@ class PlaylistTest(unittest.TestCase):
         self.assertIn(position1, lib_mock.sp_playlist_reorder_tracks.call_args[0][1])
         self.assertIn(position2, lib_mock.sp_playlist_reorder_tracks.call_args[0][1])
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_reorder_tracks_with_a_single_track(self, track_lib_mock, lib_mock):
         lib_mock.sp_playlist_reorder_tracks.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         position = 13
 
@@ -728,10 +728,10 @@ class PlaylistTest(unittest.TestCase):
             sp_playlist, [position], 1, 17
         )
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_reorder_tracks_with_duplicates(self, track_lib_mock, lib_mock):
         lib_mock.sp_playlist_reorder_tracks.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         position = 13
 
@@ -741,12 +741,12 @@ class PlaylistTest(unittest.TestCase):
             sp_playlist, [position], 1, 17
         )
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_reorder_tracks_fails_if_error(self, track_lib_mock, lib_mock):
         lib_mock.sp_playlist_reorder_tracks.return_value = int(
             spotify.ErrorType.PERMISSION_DENIED
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         position = 13
 
@@ -755,7 +755,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_num_subscribers(self, lib_mock):
         lib_mock.sp_playlist_num_subscribers.return_value = 7
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.num_subscribers
@@ -764,12 +764,12 @@ class PlaylistTest(unittest.TestCase):
         self.assertEqual(result, 7)
 
     def test_subscribers(self, lib_mock):
-        sp_subscribers = spotify.ffi.new('sp_subscribers *')
+        sp_subscribers = spotify.ffi.new("sp_subscribers *")
         sp_subscribers.count = 1
-        user_alice = spotify.ffi.new('char[]', b'alice')
+        user_alice = spotify.ffi.new("char[]", b"alice")
         sp_subscribers.subscribers = [user_alice]
         lib_mock.sp_playlist_subscribers.return_value = sp_subscribers
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.subscribers
@@ -777,11 +777,11 @@ class PlaylistTest(unittest.TestCase):
         lib_mock.sp_playlist_subscribers.assert_called_with(sp_playlist)
         tests.gc_collect()
         lib_mock.sp_playlist_subscribers_free.assert_called_with(sp_subscribers)
-        self.assertEqual(result, ['alice'])
+        self.assertEqual(result, ["alice"])
 
     def test_update_subscribers(self, lib_mock):
         lib_mock.sp_playlist_update_subscribers.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         playlist.update_subscribers()
@@ -794,7 +794,7 @@ class PlaylistTest(unittest.TestCase):
         lib_mock.sp_playlist_update_subscribers.return_value = int(
             spotify.ErrorType.BAD_API_VERSION
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         with self.assertRaises(spotify.Error):
@@ -802,7 +802,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_is_in_ram(self, lib_mock):
         lib_mock.sp_playlist_is_in_ram.return_value = 1
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.is_in_ram
@@ -814,7 +814,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_set_in_ram(self, lib_mock):
         lib_mock.sp_playlist_set_in_ram.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         playlist.set_in_ram(False)
@@ -827,7 +827,7 @@ class PlaylistTest(unittest.TestCase):
         lib_mock.sp_playlist_set_in_ram.return_value = int(
             spotify.ErrorType.BAD_API_VERSION
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         with self.assertRaises(spotify.Error):
@@ -835,7 +835,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_set_offline_mode(self, lib_mock):
         lib_mock.sp_playlist_set_offline_mode.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         playlist.set_offline_mode(False)
@@ -848,7 +848,7 @@ class PlaylistTest(unittest.TestCase):
         lib_mock.sp_playlist_set_offline_mode.return_value = int(
             spotify.ErrorType.BAD_API_VERSION
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         with self.assertRaises(spotify.Error):
@@ -856,7 +856,7 @@ class PlaylistTest(unittest.TestCase):
 
     def test_offline_status(self, lib_mock):
         lib_mock.sp_playlist_get_offline_status.return_value = 2
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.offline_status
@@ -869,7 +869,7 @@ class PlaylistTest(unittest.TestCase):
     def test_offline_download_completed(self, lib_mock):
         lib_mock.sp_playlist_get_offline_status.return_value = 2
         lib_mock.sp_playlist_get_offline_download_completed.return_value = 73
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.offline_download_completed
@@ -882,7 +882,7 @@ class PlaylistTest(unittest.TestCase):
     def test_offline_download_completed_when_not_downloading(self, lib_mock):
         lib_mock.sp_playlist_get_offline_status.return_value = 0
         lib_mock.sp_playlist_get_offline_download_completed.return_value = 0
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         result = playlist.offline_download_completed
@@ -892,11 +892,11 @@ class PlaylistTest(unittest.TestCase):
         )
         self.assertIsNone(result)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_link_creates_link_to_playlist(self, link_mock, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
-        sp_link = spotify.ffi.cast('sp_link *', 43)
+        sp_link = spotify.ffi.cast("sp_link *", 43)
         lib_mock.sp_link_create_from_playlist.return_value = sp_link
         link_mock.return_value = mock.sentinel.link
 
@@ -905,11 +905,11 @@ class PlaylistTest(unittest.TestCase):
         link_mock.assert_called_once_with(self.session, sp_link=sp_link, add_ref=False)
         self.assertEqual(result, mock.sentinel.link)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_link_fails_if_playlist_not_loaded(self, lik_mock, lib_mock):
         lib_mock.sp_playlist_is_loaded.return_value = 0
         lib_mock.sp_link_create_from_playlist.return_value = spotify.ffi.NULL
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         with self.assertRaises(spotify.Error):
@@ -918,11 +918,11 @@ class PlaylistTest(unittest.TestCase):
         # Condition is checked before link creation is tried
         self.assertEqual(lib_mock.sp_link_create_from_playlist.call_count, 0)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_link_may_fail_if_playlist_has_not_been_in_ram(self, link_mock, lib_mock):
         lib_mock.sp_playlist_is_loaded.return_value = 1
         lib_mock.sp_link_create_from_playlist.return_value = spotify.ffi.NULL
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         with self.assertRaises(spotify.Error):
@@ -935,7 +935,7 @@ class PlaylistTest(unittest.TestCase):
         )
 
     def test_first_on_call_adds_ref_to_obj_on_session(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         playlist.on(spotify.PlaylistEvent.TRACKS_ADDED, lambda *args: None)
@@ -943,7 +943,7 @@ class PlaylistTest(unittest.TestCase):
         self.assertIn(playlist, self.session._emitters)
 
     def test_last_off_call_removes_ref_to_obj_from_session(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         playlist.on(spotify.PlaylistEvent.TRACKS_ADDED, lambda *args: None)
@@ -952,7 +952,7 @@ class PlaylistTest(unittest.TestCase):
         self.assertNotIn(playlist, self.session._emitters)
 
     def test_other_off_calls_keeps_ref_to_obj_on_session(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
 
         playlist.on(spotify.PlaylistEvent.TRACKS_ADDED, lambda *args: None)
@@ -966,7 +966,7 @@ class PlaylistTest(unittest.TestCase):
         self.assertNotIn(playlist, self.session._emitters)
 
 
-@mock.patch('spotify.playlist.lib', spec=spotify.lib)
+@mock.patch("spotify.playlist.lib", spec=spotify.lib)
 class PlaylistCallbacksTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
@@ -975,16 +975,16 @@ class PlaylistCallbacksTest(unittest.TestCase):
     def tearDown(self):
         spotify._session_instance = None
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_tracks_added_callback(self, track_lib_mock, lib_mock):
         callback = mock.Mock()
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.TRACKS_ADDED, callback)
         sp_tracks = [
-            spotify.ffi.cast('sp_track *', 43),
-            spotify.ffi.cast('sp_track *', 44),
-            spotify.ffi.cast('sp_track *', 45),
+            spotify.ffi.cast("sp_track *", 43),
+            spotify.ffi.cast("sp_track *", 44),
+            spotify.ffi.cast("sp_track *", 45),
         ]
         index = 7
 
@@ -1007,7 +1007,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
 
     def test_tracks_removed_callback(self, lib_mock):
         callback = mock.Mock()
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.TRACKS_REMOVED, callback)
         track_numbers = [43, 44, 45]
@@ -1023,7 +1023,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
 
     def test_tracks_moved_callback(self, lib_mock):
         callback = mock.Mock()
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.TRACKS_MOVED, callback)
         track_numbers = [43, 44, 45]
@@ -1044,7 +1044,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
 
     def test_playlist_renamed_callback(self, lib_mock):
         callback = mock.Mock()
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.PLAYLIST_RENAMED, callback)
 
@@ -1054,7 +1054,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
 
     def test_playlist_state_changed_callback(self, lib_mock):
         callback = mock.Mock()
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.PLAYLIST_STATE_CHANGED, callback)
 
@@ -1064,7 +1064,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
 
     def test_playlist_update_in_progress_callback(self, lib_mock):
         callback = mock.Mock()
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.PLAYLIST_UPDATE_IN_PROGRESS, callback)
         done = True
@@ -1077,7 +1077,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
 
     def test_playlist_metadata_updated_callback(self, lib_mock):
         callback = mock.Mock()
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.PLAYLIST_METADATA_UPDATED, callback)
 
@@ -1085,14 +1085,14 @@ class PlaylistCallbacksTest(unittest.TestCase):
 
         callback.assert_called_once_with(playlist)
 
-    @mock.patch('spotify.user.lib', spec=spotify.lib)
+    @mock.patch("spotify.user.lib", spec=spotify.lib)
     def test_track_created_changed_callback(self, user_lib_mock, lib_mock):
         callback = mock.Mock()
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.TRACK_CREATED_CHANGED, callback)
         index = 7
-        sp_user = spotify.ffi.cast('sp_user *', 43)
+        sp_user = spotify.ffi.cast("sp_user *", 43)
         time = 123456789
 
         _PlaylistCallbacks.track_created_changed(
@@ -1107,7 +1107,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
 
     def test_track_seen_changed_callback(self, lib_mock):
         callback = mock.Mock()
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.TRACK_SEEN_CHANGED, callback)
         index = 7
@@ -1121,24 +1121,24 @@ class PlaylistCallbacksTest(unittest.TestCase):
 
     def test_description_changed_callback(self, lib_mock):
         callback = mock.Mock()
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.DESCRIPTION_CHANGED, callback)
-        description = 'foo bar æøå'
-        desc = spotify.ffi.new('char[]', description.encode('utf-8'))
+        description = "foo bar æøå"
+        desc = spotify.ffi.new("char[]", description.encode("utf-8"))
 
         _PlaylistCallbacks.description_changed(sp_playlist, desc, spotify.ffi.NULL)
 
         callback.assert_called_once_with(playlist, description)
 
-    @mock.patch('spotify.image.lib', spec=spotify.lib)
+    @mock.patch("spotify.image.lib", spec=spotify.lib)
     def test_image_changed_callback(self, image_lib_mock, lib_mock):
         callback = mock.Mock()
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.IMAGE_CHANGED, callback)
-        image_id = spotify.ffi.new('char[]', b'image-id')
-        sp_image = spotify.ffi.cast('sp_image *', 43)
+        image_id = spotify.ffi.new("char[]", b"image-id")
+        sp_image = spotify.ffi.cast("sp_image *", 43)
         lib_mock.sp_image_create.return_value = sp_image
         image_lib_mock.sp_image_add_load_callback.return_value = int(
             spotify.ErrorType.OK
@@ -1157,12 +1157,12 @@ class PlaylistCallbacksTest(unittest.TestCase):
 
     def test_track_message_changed_callback(self, lib_mock):
         callback = mock.Mock()
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.TRACK_MESSAGE_CHANGED, callback)
         index = 7
-        message = 'foo bar æøå'
-        msg = spotify.ffi.new('char[]', message.encode('utf-8'))
+        message = "foo bar æøå"
+        msg = spotify.ffi.new("char[]", message.encode("utf-8"))
 
         _PlaylistCallbacks.track_message_changed(
             sp_playlist, index, msg, spotify.ffi.NULL
@@ -1172,7 +1172,7 @@ class PlaylistCallbacksTest(unittest.TestCase):
 
     def test_subscribers_changed_callback(self, lib_mock):
         callback = mock.Mock()
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist = spotify.Playlist._cached(self.session, sp_playlist=sp_playlist)
         playlist.on(spotify.PlaylistEvent.SUBSCRIBERS_CHANGED, callback)
 

--- a/tests/test_playlist_container.py
+++ b/tests/test_playlist_container.py
@@ -10,7 +10,7 @@ from spotify.playlist_container import _PlaylistContainerCallbacks
 from tests import mock
 
 
-@mock.patch('spotify.playlist_container.lib', spec=spotify.lib)
+@mock.patch("spotify.playlist_container.lib", spec=spotify.lib)
 class PlaylistContainerTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
@@ -20,7 +20,7 @@ class PlaylistContainerTest(unittest.TestCase):
         spotify._session_instance = None
 
     def test_life_cycle(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
 
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer
@@ -52,7 +52,7 @@ class PlaylistContainerTest(unittest.TestCase):
         #     sp_playlistcontainer)
 
     def test_cached_container(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
 
         result1 = spotify.PlaylistContainer._cached(self.session, sp_playlistcontainer)
         result2 = spotify.PlaylistContainer._cached(self.session, sp_playlistcontainer)
@@ -60,25 +60,25 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertIsInstance(result1, spotify.PlaylistContainer)
         self.assertIs(result1, result2)
 
-    @mock.patch('spotify.User', spec=spotify.User)
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.User", spec=spotify.User)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_repr(self, link_mock, user_mock, lib_mock):
         link_instance_mock = link_mock.return_value
-        link_instance_mock.uri = 'foo'
+        link_instance_mock.uri = "foo"
         user_instance_mock = user_mock.return_value
         user_instance_mock.link = link_instance_mock
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 0
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
 
         result = repr(playlist_container)
 
-        self.assertEqual(result, 'PlaylistContainer([])')
+        self.assertEqual(result, "PlaylistContainer([])")
 
     def test_eq(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container1 = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -87,10 +87,10 @@ class PlaylistContainerTest(unittest.TestCase):
         )
 
         self.assertTrue(playlist_container1 == playlist_container2)
-        self.assertFalse(playlist_container1 == 'foo')
+        self.assertFalse(playlist_container1 == "foo")
 
     def test_ne(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container1 = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -101,7 +101,7 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertFalse(playlist_container1 != playlist_container2)
 
     def test_hash(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container1 = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -113,7 +113,7 @@ class PlaylistContainerTest(unittest.TestCase):
 
     def test_is_loaded(self, lib_mock):
         lib_mock.sp_playlistcontainer_is_loaded.return_value = 1
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -125,9 +125,9 @@ class PlaylistContainerTest(unittest.TestCase):
         )
         self.assertTrue(result)
 
-    @mock.patch('spotify.utils.load')
+    @mock.patch("spotify.utils.load")
     def test_load(self, load_mock, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -138,7 +138,7 @@ class PlaylistContainerTest(unittest.TestCase):
 
     def test_len(self, lib_mock):
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 8
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -152,7 +152,7 @@ class PlaylistContainerTest(unittest.TestCase):
 
     def test_len_if_undefined(self, lib_mock):
         lib_mock.sp_playlistcontainer_num_playlists.return_value = -1
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -164,15 +164,15 @@ class PlaylistContainerTest(unittest.TestCase):
         )
         self.assertEqual(result, 0)
 
-    @mock.patch('spotify.playlist.lib', lib=spotify.lib)
+    @mock.patch("spotify.playlist.lib", lib=spotify.lib)
     def test_getitem(self, playlist_lib_mock, lib_mock):
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 1
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_playlist_type.return_value = int(
             spotify.PlaylistType.PLAYLIST
         )
         lib_mock.sp_playlistcontainer_playlist.return_value = sp_playlist
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -186,15 +186,15 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertIsInstance(result, spotify.Playlist)
         self.assertEqual(result._sp_playlist, sp_playlist)
 
-    @mock.patch('spotify.playlist.lib', lib=spotify.lib)
+    @mock.patch("spotify.playlist.lib", lib=spotify.lib)
     def test_getitem_with_negative_index(self, playlist_lib_mock, lib_mock):
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 1
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_playlist_type.return_value = int(
             spotify.PlaylistType.PLAYLIST
         )
         lib_mock.sp_playlistcontainer_playlist.return_value = sp_playlist
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -208,7 +208,7 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertIsInstance(result, spotify.Playlist)
         self.assertEqual(result._sp_playlist, sp_playlist)
 
-    @mock.patch('spotify.playlist.lib', lib=spotify.lib)
+    @mock.patch("spotify.playlist.lib", lib=spotify.lib)
     def test_getitem_with_slice(self, playlist_lib_mock, lib_mock):
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 3
         lib_mock.sp_playlistcontainer_playlist_type.side_effect = [
@@ -216,15 +216,15 @@ class PlaylistContainerTest(unittest.TestCase):
             int(spotify.PlaylistType.PLAYLIST),
             int(spotify.PlaylistType.PLAYLIST),
         ]
-        sp_playlist1 = spotify.ffi.cast('sp_playlist *', 43)
-        sp_playlist2 = spotify.ffi.cast('sp_playlist *', 44)
-        sp_playlist3 = spotify.ffi.cast('sp_playlist *', 45)
+        sp_playlist1 = spotify.ffi.cast("sp_playlist *", 43)
+        sp_playlist2 = spotify.ffi.cast("sp_playlist *", 44)
+        sp_playlist3 = spotify.ffi.cast("sp_playlist *", 45)
         lib_mock.sp_playlistcontainer_playlist.side_effect = [
             sp_playlist1,
             sp_playlist2,
             sp_playlist3,
         ]
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -241,9 +241,9 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertEqual(result[0]._sp_playlist, sp_playlist1)
         self.assertEqual(result[1]._sp_playlist, sp_playlist2)
 
-    @mock.patch('spotify.playlist.lib', lib=spotify.lib)
+    @mock.patch("spotify.playlist.lib", lib=spotify.lib)
     def test_getitem_with_folder(self, playlist_lib_mock, lib_mock):
-        folder_name = 'foobar'
+        folder_name = "foobar"
 
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 3
         lib_mock.sp_playlistcontainer_playlist_type.side_effect = [
@@ -251,7 +251,7 @@ class PlaylistContainerTest(unittest.TestCase):
             int(spotify.PlaylistType.PLAYLIST),
             int(spotify.PlaylistType.END_FOLDER),
         ]
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_playlist.return_value = sp_playlist
         lib_mock.sp_playlistcontainer_playlist_folder_id.side_effect = [
             1001,
@@ -259,7 +259,7 @@ class PlaylistContainerTest(unittest.TestCase):
         ]
         func = tests.buffer_writer(folder_name)
         lib_mock.sp_playlistcontainer_playlist_folder_name.side_effect = func
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -274,7 +274,7 @@ class PlaylistContainerTest(unittest.TestCase):
         )
         self.assertIsInstance(result, spotify.PlaylistFolder)
         self.assertEqual(result.id, 1001)
-        self.assertEqual(result.name, 'foobar')
+        self.assertEqual(result.name, "foobar")
         self.assertEqual(result.type, spotify.PlaylistType.START_FOLDER)
 
         result = playlist_container[1]
@@ -307,7 +307,7 @@ class PlaylistContainerTest(unittest.TestCase):
         lib_mock.sp_playlistcontainer_playlist_type.return_value = int(
             spotify.PlaylistType.PLACEHOLDER
         )
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -319,9 +319,9 @@ class PlaylistContainerTest(unittest.TestCase):
 
     def test_getitem_raises_index_error_on_too_low_index(self, lib_mock):
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 1
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_playlist.return_value = sp_playlist
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -331,9 +331,9 @@ class PlaylistContainerTest(unittest.TestCase):
 
     def test_getitem_raises_index_error_on_too_high_index(self, lib_mock):
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 1
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_playlist.return_value = sp_playlist
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -343,18 +343,18 @@ class PlaylistContainerTest(unittest.TestCase):
 
     def test_getitem_raises_type_error_on_non_integral_index(self, lib_mock):
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 1
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_playlist.return_value = sp_playlist
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
 
         with self.assertRaises(TypeError):
-            playlist_container['abc']
+            playlist_container["abc"]
 
     def test_setitem_with_playlist_name(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -362,16 +362,16 @@ class PlaylistContainerTest(unittest.TestCase):
         playlist_container.remove_playlist = mock.Mock()
         playlist_container.add_new_playlist = mock.Mock()
 
-        playlist_container[0] = 'New playlist'
+        playlist_container[0] = "New playlist"
 
-        playlist_container.add_new_playlist.assert_called_with('New playlist', index=0)
+        playlist_container.add_new_playlist.assert_called_with("New playlist", index=0)
         playlist_container.remove_playlist.assert_called_with(1)
 
-    @mock.patch('spotify.playlist.lib', lib=spotify.lib)
+    @mock.patch("spotify.playlist.lib", lib=spotify.lib)
     def test_setitem_with_existing_playlist(self, playlist_lib_mock, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -384,11 +384,11 @@ class PlaylistContainerTest(unittest.TestCase):
         playlist_container.add_playlist.assert_called_with(playlist, index=0)
         playlist_container.remove_playlist.assert_called_with(1)
 
-    @mock.patch('spotify.playlist.lib', lib=spotify.lib)
+    @mock.patch("spotify.playlist.lib", lib=spotify.lib)
     def test_setitem_with_slice(self, playlist_lib_mock, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -397,22 +397,22 @@ class PlaylistContainerTest(unittest.TestCase):
         playlist_container.add_new_playlist = mock.Mock()
         playlist_container.add_playlist = mock.Mock()
 
-        playlist_container[0:2] = ['New playlist', playlist]
+        playlist_container[0:2] = ["New playlist", playlist]
 
-        playlist_container.add_new_playlist.assert_called_with('New playlist', index=0)
+        playlist_container.add_new_playlist.assert_called_with("New playlist", index=0)
         playlist_container.add_playlist.assert_called_with(playlist, index=1)
         playlist_container.remove_playlist.assert_has_calls(
             [mock.call(3), mock.call(2)], any_order=False
         )
 
-    @mock.patch('spotify.playlist.lib', lib=spotify.lib)
+    @mock.patch("spotify.playlist.lib", lib=spotify.lib)
     def test_setittem_with_slice_and_noniterable_value_fails(
         self, playlist_lib_mock, lib_mock
     ):
 
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -424,7 +424,7 @@ class PlaylistContainerTest(unittest.TestCase):
             playlist_container[0:2] = playlist
 
     def test_setitem_raises_error_on_unknown_playlist_type(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -439,7 +439,7 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertEqual(playlist_container.remove_playlist.call_count, 0)
 
     def test_setitem_raises_index_error_on_negative_index(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -449,7 +449,7 @@ class PlaylistContainerTest(unittest.TestCase):
             playlist_container[-1] = None
 
     def test_setitem_raises_index_error_on_too_high_index(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -459,17 +459,17 @@ class PlaylistContainerTest(unittest.TestCase):
             playlist_container[1] = None
 
     def test_setitem_raises_type_error_on_non_integral_index(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
         playlist_container.__len__ = mock.Mock(return_value=1)
 
         with self.assertRaises(TypeError):
-            playlist_container['abc'] = None
+            playlist_container["abc"] = None
 
     def test_delitem(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -481,7 +481,7 @@ class PlaylistContainerTest(unittest.TestCase):
         playlist_container.remove_playlist.assert_called_with(0)
 
     def test_delitem_with_slice(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -496,7 +496,7 @@ class PlaylistContainerTest(unittest.TestCase):
         )
 
     def test_delitem_raises_index_error_on_negative_index(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -506,7 +506,7 @@ class PlaylistContainerTest(unittest.TestCase):
             del playlist_container[-1]
 
     def test_delitem_raises_index_error_on_too_high_index(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -516,17 +516,17 @@ class PlaylistContainerTest(unittest.TestCase):
             del playlist_container[1]
 
     def test_delitem_raises_type_error_on_non_integral_index(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
         playlist_container.__len__ = mock.Mock(return_value=1)
 
         with self.assertRaises(TypeError):
-            del playlist_container['abc']
+            del playlist_container["abc"]
 
     def test_insert_with_playlist_name(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -534,15 +534,15 @@ class PlaylistContainerTest(unittest.TestCase):
         playlist_container.remove_playlist = mock.Mock()
         playlist_container.add_new_playlist = mock.Mock()
 
-        playlist_container.insert(3, 'New playlist')
+        playlist_container.insert(3, "New playlist")
 
-        playlist_container.add_new_playlist.assert_called_with('New playlist', index=3)
+        playlist_container.add_new_playlist.assert_called_with("New playlist", index=3)
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_insert_with_existing_playlist(self, playlist_lib_mock, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -555,7 +555,7 @@ class PlaylistContainerTest(unittest.TestCase):
         playlist_container.add_playlist.assert_called_with(playlist, index=3)
 
     def test_is_a_sequence(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -563,24 +563,24 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertIsInstance(playlist_container, compat.Sequence)
 
     def test_is_a_mutable_sequence(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
 
         self.assertIsInstance(playlist_container, compat.MutableSequence)
 
-    @mock.patch('spotify.playlist.lib', lib=spotify.lib)
+    @mock.patch("spotify.playlist.lib", lib=spotify.lib)
     def test_add_new_playlist_to_end_of_container(self, playlist_lib_mock, lib_mock):
 
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_add_new_playlist.return_value = sp_playlist
 
-        result = playlist_container.add_new_playlist('foo bar')
+        result = playlist_container.add_new_playlist("foo bar")
 
         lib_mock.sp_playlistcontainer_add_new_playlist.assert_called_with(
             sp_playlistcontainer, mock.ANY
@@ -589,28 +589,28 @@ class PlaylistContainerTest(unittest.TestCase):
             spotify.ffi.string(
                 lib_mock.sp_playlistcontainer_add_new_playlist.call_args[0][1]
             ),
-            b'foo bar',
+            b"foo bar",
         )
         self.assertIsInstance(result, spotify.Playlist)
         self.assertEqual(result._sp_playlist, sp_playlist)
         playlist_lib_mock.sp_playlist_add_ref.assert_called_with(sp_playlist)
         self.assertEqual(lib_mock.sp_playlistcontainer_move_playlist.call_count, 0)
 
-    @mock.patch('spotify.playlist.lib', lib=spotify.lib)
+    @mock.patch("spotify.playlist.lib", lib=spotify.lib)
     def test_add_new_playlist_at_given_index(self, playlist_lib_mock, lib_mock):
 
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_add_new_playlist.return_value = sp_playlist
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 100
         lib_mock.sp_playlistcontainer_move_playlist.return_value = int(
             spotify.ErrorType.OK
         )
 
-        result = playlist_container.add_new_playlist('foo bar', index=7)
+        result = playlist_container.add_new_playlist("foo bar", index=7)
 
         lib_mock.sp_playlistcontainer_add_new_playlist.assert_called_with(
             sp_playlistcontainer, mock.ANY
@@ -619,7 +619,7 @@ class PlaylistContainerTest(unittest.TestCase):
             spotify.ffi.string(
                 lib_mock.sp_playlistcontainer_add_new_playlist.call_args[0][1]
             ),
-            b'foo bar',
+            b"foo bar",
         )
         self.assertIsInstance(result, spotify.Playlist)
         self.assertEqual(result._sp_playlist, sp_playlist)
@@ -629,53 +629,53 @@ class PlaylistContainerTest(unittest.TestCase):
         )
 
     def test_add_new_playlist_fails_if_name_is_space_only(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
 
         with self.assertRaises(ValueError):
-            playlist_container.add_new_playlist('   ')
+            playlist_container.add_new_playlist("   ")
 
         # Spotify seems to accept e.g. tab-only names, but it doesn't make any
         # sense to allow it, so we disallow names with all combinations of just
         # whitespace.
         with self.assertRaises(ValueError):
-            playlist_container.add_new_playlist('\t\t')
+            playlist_container.add_new_playlist("\t\t")
         with self.assertRaises(ValueError):
-            playlist_container.add_new_playlist('\r\r')
+            playlist_container.add_new_playlist("\r\r")
         with self.assertRaises(ValueError):
-            playlist_container.add_new_playlist('\n\n')
+            playlist_container.add_new_playlist("\n\n")
         with self.assertRaises(ValueError):
-            playlist_container.add_new_playlist(' \t\r\n')
+            playlist_container.add_new_playlist(" \t\r\n")
 
     def test_add_new_playlist_fails_if_name_is_too_long(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
 
         with self.assertRaises(ValueError):
-            playlist_container.add_new_playlist('x' * 300)
+            playlist_container.add_new_playlist("x" * 300)
 
     def test_add_new_playlist_fails_if_operation_fails(self, lib_mock):
         lib_mock.sp_playlistcontainer_add_new_playlist.return_value = spotify.ffi.NULL
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
 
         with self.assertRaises(spotify.Error):
-            playlist_container.add_new_playlist('foo bar')
+            playlist_container.add_new_playlist("foo bar")
 
-    @mock.patch('spotify.link.lib', lib=spotify.lib)
-    @mock.patch('spotify.playlist.lib', lib=spotify.lib)
+    @mock.patch("spotify.link.lib", lib=spotify.lib)
+    @mock.patch("spotify.playlist.lib", lib=spotify.lib)
     def test_add_playlist_from_link(self, playlist_lib_mock, link_lib_mock, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 43)
+        sp_link = spotify.ffi.cast("sp_link *", 43)
         link = spotify.Link(self.session, sp_link=sp_link, add_ref=False)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 44)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 44)
         lib_mock.sp_playlistcontainer_add_playlist.return_value = sp_playlist
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -690,18 +690,18 @@ class PlaylistContainerTest(unittest.TestCase):
         playlist_lib_mock.sp_playlist_add_ref.assert_called_with(sp_playlist)
         self.assertEqual(lib_mock.sp_playlistcontainer_move_playlist.call_count, 0)
 
-    @mock.patch('spotify.link.lib', lib=spotify.lib)
-    @mock.patch('spotify.playlist.lib', lib=spotify.lib)
+    @mock.patch("spotify.link.lib", lib=spotify.lib)
+    @mock.patch("spotify.playlist.lib", lib=spotify.lib)
     def test_add_playlist_from_playlist(
         self, playlist_lib_mock, link_lib_mock, lib_mock
     ):
-        sp_link = spotify.ffi.cast('sp_link *', 43)
+        sp_link = spotify.ffi.cast("sp_link *", 43)
         link = spotify.Link(self.session, sp_link=sp_link, add_ref=False)
         existing_playlist = mock.Mock(spec=spotify.Playlist)
         existing_playlist.link = link
-        added_sp_playlist = spotify.ffi.cast('sp_playlist *', 44)
+        added_sp_playlist = spotify.ffi.cast("sp_playlist *", 44)
         lib_mock.sp_playlistcontainer_add_playlist.return_value = added_sp_playlist
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -716,16 +716,16 @@ class PlaylistContainerTest(unittest.TestCase):
         playlist_lib_mock.sp_playlist_add_ref.assert_called_with(added_sp_playlist)
         self.assertEqual(lib_mock.sp_playlistcontainer_move_playlist.call_count, 0)
 
-    @mock.patch('spotify.link.lib', lib=spotify.lib)
-    @mock.patch('spotify.playlist.lib', lib=spotify.lib)
+    @mock.patch("spotify.link.lib", lib=spotify.lib)
+    @mock.patch("spotify.playlist.lib", lib=spotify.lib)
     def test_add_playlist_at_given_index(
         self, playlist_lib_mock, link_lib_mock, lib_mock
     ):
-        sp_link = spotify.ffi.cast('sp_link *', 43)
+        sp_link = spotify.ffi.cast("sp_link *", 43)
         link = spotify.Link(self.session, sp_link=sp_link, add_ref=False)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 44)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 44)
         lib_mock.sp_playlistcontainer_add_playlist.return_value = sp_playlist
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -746,12 +746,12 @@ class PlaylistContainerTest(unittest.TestCase):
             sp_playlistcontainer, 99, 7, 0
         )
 
-    @mock.patch('spotify.link.lib', lib=spotify.lib)
+    @mock.patch("spotify.link.lib", lib=spotify.lib)
     def test_add_playlist_already_in_the_container(self, link_lib_mock, lib_mock):
-        sp_link = spotify.ffi.cast('sp_link *', 43)
+        sp_link = spotify.ffi.cast("sp_link *", 43)
         link = spotify.Link(self.session, sp_link=sp_link, add_ref=False)
         lib_mock.sp_playlistcontainer_add_playlist.return_value = spotify.ffi.NULL
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -765,7 +765,7 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertEqual(lib_mock.sp_playlistcontainer_move_playlist.call_count, 0)
 
     def test_add_playlist_from_unknown_type_fails(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -777,12 +777,12 @@ class PlaylistContainerTest(unittest.TestCase):
         lib_mock.sp_playlistcontainer_add_folder.return_value = int(
             spotify.ErrorType.OK
         )
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
 
-        playlist_container.add_folder('foo bar', index=3)
+        playlist_container.add_folder("foo bar", index=3)
 
         lib_mock.sp_playlistcontainer_add_folder.assert_called_with(
             sp_playlistcontainer, 3, mock.ANY
@@ -791,7 +791,7 @@ class PlaylistContainerTest(unittest.TestCase):
             spotify.ffi.string(
                 lib_mock.sp_playlistcontainer_add_folder.call_args[0][2]
             ),
-            b'foo bar',
+            b"foo bar",
         )
 
     def test_add_folder_without_index_adds_to_end(self, lib_mock):
@@ -799,12 +799,12 @@ class PlaylistContainerTest(unittest.TestCase):
         lib_mock.sp_playlistcontainer_add_folder.return_value = int(
             spotify.ErrorType.OK
         )
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
 
-        playlist_container.add_folder('foo bar')
+        playlist_container.add_folder("foo bar")
 
         lib_mock.sp_playlistcontainer_add_folder.assert_called_with(
             sp_playlistcontainer, 7, mock.ANY
@@ -813,7 +813,7 @@ class PlaylistContainerTest(unittest.TestCase):
             spotify.ffi.string(
                 lib_mock.sp_playlistcontainer_add_folder.call_args[0][2]
             ),
-            b'foo bar',
+            b"foo bar",
         )
 
     def test_add_folder_out_of_range_fails(self, lib_mock):
@@ -821,52 +821,52 @@ class PlaylistContainerTest(unittest.TestCase):
             spotify.ErrorType.INDEX_OUT_OF_RANGE
         )
 
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
 
         with self.assertRaises(spotify.Error):
-            playlist_container.add_folder('foo bar', index=3)
+            playlist_container.add_folder("foo bar", index=3)
 
     def test_add_folder_fails_if_name_is_space_only(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
 
         with self.assertRaises(ValueError):
-            playlist_container.add_folder('   ')
+            playlist_container.add_folder("   ")
 
         # Spotify seems to accept e.g. tab-only names, but it doesn't make any
         # sense to allow it, so we disallow names with all combinations of just
         # whitespace.
         with self.assertRaises(ValueError):
-            playlist_container.add_folder('\t\t')
+            playlist_container.add_folder("\t\t")
         with self.assertRaises(ValueError):
-            playlist_container.add_folder('\r\r')
+            playlist_container.add_folder("\r\r")
         with self.assertRaises(ValueError):
-            playlist_container.add_folder('\n\n')
+            playlist_container.add_folder("\n\n")
         with self.assertRaises(ValueError):
-            playlist_container.add_folder(' \t\r\n')
+            playlist_container.add_folder(" \t\r\n")
 
     def test_add_folder_fails_if_name_is_too_long(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
 
         with self.assertRaises(ValueError):
-            playlist_container.add_folder('x' * 300)
+            playlist_container.add_folder("x" * 300)
 
-    @mock.patch('spotify.playlist.lib', lib=spotify.lib)
+    @mock.patch("spotify.playlist.lib", lib=spotify.lib)
     def test_remove_playlist(self, playlist_lib_mock, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 9
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_playlist.return_value = sp_playlist
         lib_mock.sp_playlistcontainer_playlist_type.return_value = int(
             spotify.PlaylistType.PLAYLIST
@@ -881,15 +881,15 @@ class PlaylistContainerTest(unittest.TestCase):
             sp_playlistcontainer, 5
         )
 
-    @mock.patch('spotify.playlist.lib', lib=spotify.lib)
+    @mock.patch("spotify.playlist.lib", lib=spotify.lib)
     def test_remove_playlist_out_of_range_fails(self, playlist_lib_mock, lib_mock):
 
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 9
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_playlist.return_value = sp_playlist
         lib_mock.sp_playlistcontainer_playlist_type.return_value = int(
             spotify.PlaylistType.PLAYLIST
@@ -902,12 +902,12 @@ class PlaylistContainerTest(unittest.TestCase):
             playlist_container.remove_playlist(3)
 
     def test_remove_start_folder_removes_end_folder_too(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 3
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_playlist.return_value = sp_playlist
         lib_mock.sp_playlistcontainer_playlist_type.side_effect = [
             int(spotify.PlaylistType.START_FOLDER),
@@ -940,12 +940,12 @@ class PlaylistContainerTest(unittest.TestCase):
         )
 
     def test_remove_end_folder_removes_start_folder_too(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 3
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_playlist.return_value = sp_playlist
         lib_mock.sp_playlistcontainer_playlist_type.side_effect = [
             int(spotify.PlaylistType.START_FOLDER),
@@ -978,12 +978,12 @@ class PlaylistContainerTest(unittest.TestCase):
         )
 
     def test_remove_folder_with_everything_in_it(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 3
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_playlist.return_value = sp_playlist
         lib_mock.sp_playlistcontainer_playlist_type.side_effect = [
             int(spotify.PlaylistType.START_FOLDER),
@@ -1016,14 +1016,14 @@ class PlaylistContainerTest(unittest.TestCase):
             any_order=False,
         )
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_find_folder_indexes(self, playlist_lib_mock, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         playlists = [
-            spotify.PlaylistFolder(173, 'foo', spotify.PlaylistType.START_FOLDER),
+            spotify.PlaylistFolder(173, "foo", spotify.PlaylistType.START_FOLDER),
             playlist,
-            spotify.PlaylistFolder(173, '', spotify.PlaylistType.END_FOLDER),
+            spotify.PlaylistFolder(173, "", spotify.PlaylistType.END_FOLDER),
         ]
 
         result = spotify.PlaylistContainer._find_folder_indexes(
@@ -1032,15 +1032,15 @@ class PlaylistContainerTest(unittest.TestCase):
 
         self.assertEqual(result, [0, 2])
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_find_folder_indexes_with_unknown_id(self, playlist_lib_mock, lib_mock):
 
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         playlists = [
-            spotify.PlaylistFolder(173, 'foo', spotify.PlaylistType.START_FOLDER),
+            spotify.PlaylistFolder(173, "foo", spotify.PlaylistType.START_FOLDER),
             playlist,
-            spotify.PlaylistFolder(173, '', spotify.PlaylistType.END_FOLDER),
+            spotify.PlaylistFolder(173, "", spotify.PlaylistType.END_FOLDER),
         ]
 
         result = spotify.PlaylistContainer._find_folder_indexes(
@@ -1049,14 +1049,14 @@ class PlaylistContainerTest(unittest.TestCase):
 
         self.assertEqual(result, [])
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_find_folder_indexes_recursive(self, playlist_lib_mock, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         playlists = [
-            spotify.PlaylistFolder(173, 'foo', spotify.PlaylistType.START_FOLDER),
+            spotify.PlaylistFolder(173, "foo", spotify.PlaylistType.START_FOLDER),
             playlist,
-            spotify.PlaylistFolder(173, '', spotify.PlaylistType.END_FOLDER),
+            spotify.PlaylistFolder(173, "", spotify.PlaylistType.END_FOLDER),
         ]
 
         result = spotify.PlaylistContainer._find_folder_indexes(
@@ -1065,13 +1065,13 @@ class PlaylistContainerTest(unittest.TestCase):
 
         self.assertEqual(result, [0, 1, 2])
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_find_folder_indexes_without_end(self, playlist_lib_mock, lib_mock):
 
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         playlists = [
-            spotify.PlaylistFolder(173, 'foo', spotify.PlaylistType.START_FOLDER),
+            spotify.PlaylistFolder(173, "foo", spotify.PlaylistType.START_FOLDER),
             playlist,
         ]
 
@@ -1081,14 +1081,14 @@ class PlaylistContainerTest(unittest.TestCase):
 
         self.assertEqual(result, [0])
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_find_folder_indexes_without_start(self, playlist_lib_mock, lib_mock):
 
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         playlists = [
             playlist,
-            spotify.PlaylistFolder(173, '', spotify.PlaylistType.END_FOLDER),
+            spotify.PlaylistFolder(173, "", spotify.PlaylistType.END_FOLDER),
         ]
 
         result = spotify.PlaylistContainer._find_folder_indexes(
@@ -1101,7 +1101,7 @@ class PlaylistContainerTest(unittest.TestCase):
         lib_mock.sp_playlistcontainer_move_playlist.return_value = int(
             spotify.ErrorType.OK
         )
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -1116,7 +1116,7 @@ class PlaylistContainerTest(unittest.TestCase):
         lib_mock.sp_playlistcontainer_move_playlist.return_value = int(
             spotify.ErrorType.OK
         )
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -1131,7 +1131,7 @@ class PlaylistContainerTest(unittest.TestCase):
         lib_mock.sp_playlistcontainer_move_playlist.return_value = int(
             spotify.ErrorType.INDEX_OUT_OF_RANGE
         )
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -1143,7 +1143,7 @@ class PlaylistContainerTest(unittest.TestCase):
         lib_mock.sp_playlistcontainer_move_playlist.return_value = int(
             spotify.ErrorType.INVALID_INDATA
         )
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -1152,12 +1152,12 @@ class PlaylistContainerTest(unittest.TestCase):
 
         self.assertEqual(lib_mock.sp_playlistcontainer_move_playlist.call_count, 0)
 
-    @mock.patch('spotify.User', spec=spotify.User)
+    @mock.patch("spotify.User", spec=spotify.User)
     def test_owner(self, user_mock, lib_mock):
         user_mock.return_value = mock.sentinel.user
-        sp_user = spotify.ffi.cast('sp_user *', 43)
+        sp_user = spotify.ffi.cast("sp_user *", 43)
         lib_mock.sp_playlistcontainer_owner.return_value = sp_user
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -1168,15 +1168,15 @@ class PlaylistContainerTest(unittest.TestCase):
         user_mock.assert_called_with(self.session, sp_user=sp_user, add_ref=True)
         self.assertEqual(result, mock.sentinel.user)
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
-    @mock.patch('spotify.playlist_unseen_tracks.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
+    @mock.patch("spotify.playlist_unseen_tracks.lib", spec=spotify.lib)
     def test_get_unseen_tracks(self, unseen_lib_mock, playlist_lib_mock, lib_mock):
 
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         unseen_lib_mock.sp_playlistcontainer_get_unseen_tracks.return_value = 0
 
@@ -1185,13 +1185,13 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertIsInstance(result, spotify.PlaylistUnseenTracks)
         self.assertEqual(len(result), 0)
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_clear_unseen_tracks(self, playlist_lib_mock, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         lib_mock.sp_playlistcontainer_clear_unseen_tracks.return_value = 0
 
@@ -1201,16 +1201,16 @@ class PlaylistContainerTest(unittest.TestCase):
             sp_playlistcontainer, sp_playlist
         )
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_clear_unseen_tracks_raises_error_on_failure(
         self, playlist_lib_mock, lib_mock
     ):
 
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         lib_mock.sp_playlistcontainer_clear_unseen_tracks.return_value = -1
 
@@ -1218,7 +1218,7 @@ class PlaylistContainerTest(unittest.TestCase):
             playlist_container.clear_unseen_tracks(playlist)
 
     def test_first_on_call_adds_obj_emitters_list(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -1232,7 +1232,7 @@ class PlaylistContainerTest(unittest.TestCase):
         playlist_container.off()
 
     def test_last_off_call_removes_obj_from_emitters_list(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -1245,7 +1245,7 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertNotIn(playlist_container, self.session._emitters)
 
     def test_other_off_calls_keeps_obj_in_emitters_list(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -1265,8 +1265,8 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertNotIn(playlist_container, self.session._emitters)
 
 
-@unittest.skipIf('TRAVIS' in os.environ, 'Crashes on Travis trusty with Python 3.5.0')
-@mock.patch('spotify.playlist_container.lib', spec=spotify.lib)
+@unittest.skipIf("TRAVIS" in os.environ, "Crashes on Travis trusty with Python 3.5.0")
+@mock.patch("spotify.playlist_container.lib", spec=spotify.lib)
 class PlaylistContainerCallbacksTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
@@ -1275,11 +1275,11 @@ class PlaylistContainerCallbacksTest(unittest.TestCase):
     def tearDown(self):
         spotify._session_instance = None
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_playlist_added_callback(self, playlist_lib_mock, lib_mock):
         callback = mock.Mock()
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 43)
         playlist_container = spotify.PlaylistContainer._cached(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -1294,11 +1294,11 @@ class PlaylistContainerCallbacksTest(unittest.TestCase):
         self.assertIsInstance(playlist, spotify.Playlist)
         self.assertEqual(playlist._sp_playlist, sp_playlist)
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_playlist_removed_callback(self, playlist_lib_mock, lib_mock):
         callback = mock.Mock()
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 43)
         playlist_container = spotify.PlaylistContainer._cached(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -1313,11 +1313,11 @@ class PlaylistContainerCallbacksTest(unittest.TestCase):
         self.assertIsInstance(playlist, spotify.Playlist)
         self.assertEqual(playlist._sp_playlist, sp_playlist)
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_playlist_moved_callback(self, playlist_lib_mock, lib_mock):
         callback = mock.Mock()
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 43)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 43)
         playlist_container = spotify.PlaylistContainer._cached(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -1334,7 +1334,7 @@ class PlaylistContainerCallbacksTest(unittest.TestCase):
 
     def test_container_loaded_callback(self, lib_mock):
         callback = mock.Mock()
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 43)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 43)
         playlist_container = spotify.PlaylistContainer._cached(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
@@ -1350,21 +1350,21 @@ class PlaylistContainerCallbacksTest(unittest.TestCase):
 class PlaylistFolderTest(unittest.TestCase):
     def test_id(self):
         folder = spotify.PlaylistFolder(
-            id=123, name='foo', type=spotify.PlaylistType.START_FOLDER
+            id=123, name="foo", type=spotify.PlaylistType.START_FOLDER
         )
 
         self.assertEqual(folder.id, 123)
 
     def test_image(self):
         folder = spotify.PlaylistFolder(
-            id=123, name='foo', type=spotify.PlaylistType.START_FOLDER
+            id=123, name="foo", type=spotify.PlaylistType.START_FOLDER
         )
 
-        self.assertEqual(folder.name, 'foo')
+        self.assertEqual(folder.name, "foo")
 
     def test_type(self):
         folder = spotify.PlaylistFolder(
-            id=123, name='foo', type=spotify.PlaylistType.START_FOLDER
+            id=123, name="foo", type=spotify.PlaylistType.START_FOLDER
         )
 
         self.assertEqual(folder.type, spotify.PlaylistType.START_FOLDER)

--- a/tests/test_playlist_container.py
+++ b/tests/test_playlist_container.py
@@ -4,10 +4,9 @@ import os
 import unittest
 
 import spotify
+import tests
 from spotify import compat
 from spotify.playlist_container import _PlaylistContainerCallbacks
-
-import tests
 from tests import mock
 
 

--- a/tests/test_playlist_container.py
+++ b/tests/test_playlist_container.py
@@ -26,9 +26,7 @@ class PlaylistContainerTest(unittest.TestCase):
             self.session, sp_playlistcontainer
         )
 
-        lib_mock.sp_playlistcontainer_add_ref.assert_called_with(
-            sp_playlistcontainer
-        )
+        lib_mock.sp_playlistcontainer_add_ref.assert_called_with(sp_playlistcontainer)
 
         # Callbacks are only added when someone registers a Python event
         # handler on the container:
@@ -56,12 +54,8 @@ class PlaylistContainerTest(unittest.TestCase):
     def test_cached_container(self, lib_mock):
         sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
 
-        result1 = spotify.PlaylistContainer._cached(
-            self.session, sp_playlistcontainer
-        )
-        result2 = spotify.PlaylistContainer._cached(
-            self.session, sp_playlistcontainer
-        )
+        result1 = spotify.PlaylistContainer._cached(self.session, sp_playlistcontainer)
+        result2 = spotify.PlaylistContainer._cached(self.session, sp_playlistcontainer)
 
         self.assertIsInstance(result1, spotify.PlaylistContainer)
         self.assertIs(result1, result2)
@@ -140,9 +134,7 @@ class PlaylistContainerTest(unittest.TestCase):
 
         playlist_container.load(10)
 
-        load_mock.assert_called_with(
-            self.session, playlist_container, timeout=10
-        )
+        load_mock.assert_called_with(self.session, playlist_container, timeout=10)
 
     def test_len(self, lib_mock):
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 8
@@ -372,9 +364,7 @@ class PlaylistContainerTest(unittest.TestCase):
 
         playlist_container[0] = 'New playlist'
 
-        playlist_container.add_new_playlist.assert_called_with(
-            'New playlist', index=0
-        )
+        playlist_container.add_new_playlist.assert_called_with('New playlist', index=0)
         playlist_container.remove_playlist.assert_called_with(1)
 
     @mock.patch('spotify.playlist.lib', lib=spotify.lib)
@@ -409,9 +399,7 @@ class PlaylistContainerTest(unittest.TestCase):
 
         playlist_container[0:2] = ['New playlist', playlist]
 
-        playlist_container.add_new_playlist.assert_called_with(
-            'New playlist', index=0
-        )
+        playlist_container.add_new_playlist.assert_called_with('New playlist', index=0)
         playlist_container.add_playlist.assert_called_with(playlist, index=1)
         playlist_container.remove_playlist.assert_has_calls(
             [mock.call(3), mock.call(2)], any_order=False
@@ -548,9 +536,7 @@ class PlaylistContainerTest(unittest.TestCase):
 
         playlist_container.insert(3, 'New playlist')
 
-        playlist_container.add_new_playlist.assert_called_with(
-            'New playlist', index=3
-        )
+        playlist_container.add_new_playlist.assert_called_with('New playlist', index=3)
 
     @mock.patch('spotify.playlist.lib', spec=spotify.lib)
     def test_insert_with_existing_playlist(self, playlist_lib_mock, lib_mock):
@@ -585,18 +571,14 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertIsInstance(playlist_container, compat.MutableSequence)
 
     @mock.patch('spotify.playlist.lib', lib=spotify.lib)
-    def test_add_new_playlist_to_end_of_container(
-        self, playlist_lib_mock, lib_mock
-    ):
+    def test_add_new_playlist_to_end_of_container(self, playlist_lib_mock, lib_mock):
 
         sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
         sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
-        lib_mock.sp_playlistcontainer_add_new_playlist.return_value = (
-            sp_playlist
-        )
+        lib_mock.sp_playlistcontainer_add_new_playlist.return_value = sp_playlist
 
         result = playlist_container.add_new_playlist('foo bar')
 
@@ -612,9 +594,7 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertIsInstance(result, spotify.Playlist)
         self.assertEqual(result._sp_playlist, sp_playlist)
         playlist_lib_mock.sp_playlist_add_ref.assert_called_with(sp_playlist)
-        self.assertEqual(
-            lib_mock.sp_playlistcontainer_move_playlist.call_count, 0
-        )
+        self.assertEqual(lib_mock.sp_playlistcontainer_move_playlist.call_count, 0)
 
     @mock.patch('spotify.playlist.lib', lib=spotify.lib)
     def test_add_new_playlist_at_given_index(self, playlist_lib_mock, lib_mock):
@@ -624,9 +604,7 @@ class PlaylistContainerTest(unittest.TestCase):
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
         sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
-        lib_mock.sp_playlistcontainer_add_new_playlist.return_value = (
-            sp_playlist
-        )
+        lib_mock.sp_playlistcontainer_add_new_playlist.return_value = sp_playlist
         lib_mock.sp_playlistcontainer_num_playlists.return_value = 100
         lib_mock.sp_playlistcontainer_move_playlist.return_value = int(
             spotify.ErrorType.OK
@@ -681,9 +659,7 @@ class PlaylistContainerTest(unittest.TestCase):
             playlist_container.add_new_playlist('x' * 300)
 
     def test_add_new_playlist_fails_if_operation_fails(self, lib_mock):
-        lib_mock.sp_playlistcontainer_add_new_playlist.return_value = (
-            spotify.ffi.NULL
-        )
+        lib_mock.sp_playlistcontainer_add_new_playlist.return_value = spotify.ffi.NULL
         sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
@@ -694,9 +670,7 @@ class PlaylistContainerTest(unittest.TestCase):
 
     @mock.patch('spotify.link.lib', lib=spotify.lib)
     @mock.patch('spotify.playlist.lib', lib=spotify.lib)
-    def test_add_playlist_from_link(
-        self, playlist_lib_mock, link_lib_mock, lib_mock
-    ):
+    def test_add_playlist_from_link(self, playlist_lib_mock, link_lib_mock, lib_mock):
         sp_link = spotify.ffi.cast('sp_link *', 43)
         link = spotify.Link(self.session, sp_link=sp_link, add_ref=False)
         sp_playlist = spotify.ffi.cast('sp_playlist *', 44)
@@ -714,9 +688,7 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertIsInstance(result, spotify.Playlist)
         self.assertEqual(result._sp_playlist, sp_playlist)
         playlist_lib_mock.sp_playlist_add_ref.assert_called_with(sp_playlist)
-        self.assertEqual(
-            lib_mock.sp_playlistcontainer_move_playlist.call_count, 0
-        )
+        self.assertEqual(lib_mock.sp_playlistcontainer_move_playlist.call_count, 0)
 
     @mock.patch('spotify.link.lib', lib=spotify.lib)
     @mock.patch('spotify.playlist.lib', lib=spotify.lib)
@@ -728,9 +700,7 @@ class PlaylistContainerTest(unittest.TestCase):
         existing_playlist = mock.Mock(spec=spotify.Playlist)
         existing_playlist.link = link
         added_sp_playlist = spotify.ffi.cast('sp_playlist *', 44)
-        lib_mock.sp_playlistcontainer_add_playlist.return_value = (
-            added_sp_playlist
-        )
+        lib_mock.sp_playlistcontainer_add_playlist.return_value = added_sp_playlist
         sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
@@ -743,12 +713,8 @@ class PlaylistContainerTest(unittest.TestCase):
         )
         self.assertIsInstance(result, spotify.Playlist)
         self.assertEqual(result._sp_playlist, added_sp_playlist)
-        playlist_lib_mock.sp_playlist_add_ref.assert_called_with(
-            added_sp_playlist
-        )
-        self.assertEqual(
-            lib_mock.sp_playlistcontainer_move_playlist.call_count, 0
-        )
+        playlist_lib_mock.sp_playlist_add_ref.assert_called_with(added_sp_playlist)
+        self.assertEqual(lib_mock.sp_playlistcontainer_move_playlist.call_count, 0)
 
     @mock.patch('spotify.link.lib', lib=spotify.lib)
     @mock.patch('spotify.playlist.lib', lib=spotify.lib)
@@ -781,14 +747,10 @@ class PlaylistContainerTest(unittest.TestCase):
         )
 
     @mock.patch('spotify.link.lib', lib=spotify.lib)
-    def test_add_playlist_already_in_the_container(
-        self, link_lib_mock, lib_mock
-    ):
+    def test_add_playlist_already_in_the_container(self, link_lib_mock, lib_mock):
         sp_link = spotify.ffi.cast('sp_link *', 43)
         link = spotify.Link(self.session, sp_link=sp_link, add_ref=False)
-        lib_mock.sp_playlistcontainer_add_playlist.return_value = (
-            spotify.ffi.NULL
-        )
+        lib_mock.sp_playlistcontainer_add_playlist.return_value = spotify.ffi.NULL
         sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
         playlist_container = spotify.PlaylistContainer(
             self.session, sp_playlistcontainer=sp_playlistcontainer
@@ -800,9 +762,7 @@ class PlaylistContainerTest(unittest.TestCase):
             sp_playlistcontainer, sp_link
         )
         self.assertIsNone(result)
-        self.assertEqual(
-            lib_mock.sp_playlistcontainer_move_playlist.call_count, 0
-        )
+        self.assertEqual(lib_mock.sp_playlistcontainer_move_playlist.call_count, 0)
 
     def test_add_playlist_from_unknown_type_fails(self, lib_mock):
         sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
@@ -922,9 +882,7 @@ class PlaylistContainerTest(unittest.TestCase):
         )
 
     @mock.patch('spotify.playlist.lib', lib=spotify.lib)
-    def test_remove_playlist_out_of_range_fails(
-        self, playlist_lib_mock, lib_mock
-    ):
+    def test_remove_playlist_out_of_range_fails(self, playlist_lib_mock, lib_mock):
 
         sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
         playlist_container = spotify.PlaylistContainer(
@@ -1063,9 +1021,7 @@ class PlaylistContainerTest(unittest.TestCase):
         sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         playlists = [
-            spotify.PlaylistFolder(
-                173, 'foo', spotify.PlaylistType.START_FOLDER
-            ),
+            spotify.PlaylistFolder(173, 'foo', spotify.PlaylistType.START_FOLDER),
             playlist,
             spotify.PlaylistFolder(173, '', spotify.PlaylistType.END_FOLDER),
         ]
@@ -1077,16 +1033,12 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertEqual(result, [0, 2])
 
     @mock.patch('spotify.playlist.lib', spec=spotify.lib)
-    def test_find_folder_indexes_with_unknown_id(
-        self, playlist_lib_mock, lib_mock
-    ):
+    def test_find_folder_indexes_with_unknown_id(self, playlist_lib_mock, lib_mock):
 
         sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         playlists = [
-            spotify.PlaylistFolder(
-                173, 'foo', spotify.PlaylistType.START_FOLDER
-            ),
+            spotify.PlaylistFolder(173, 'foo', spotify.PlaylistType.START_FOLDER),
             playlist,
             spotify.PlaylistFolder(173, '', spotify.PlaylistType.END_FOLDER),
         ]
@@ -1102,9 +1054,7 @@ class PlaylistContainerTest(unittest.TestCase):
         sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         playlists = [
-            spotify.PlaylistFolder(
-                173, 'foo', spotify.PlaylistType.START_FOLDER
-            ),
+            spotify.PlaylistFolder(173, 'foo', spotify.PlaylistType.START_FOLDER),
             playlist,
             spotify.PlaylistFolder(173, '', spotify.PlaylistType.END_FOLDER),
         ]
@@ -1121,9 +1071,7 @@ class PlaylistContainerTest(unittest.TestCase):
         sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
         playlists = [
-            spotify.PlaylistFolder(
-                173, 'foo', spotify.PlaylistType.START_FOLDER
-            ),
+            spotify.PlaylistFolder(173, 'foo', spotify.PlaylistType.START_FOLDER),
             playlist,
         ]
 
@@ -1134,9 +1082,7 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertEqual(result, [0])
 
     @mock.patch('spotify.playlist.lib', spec=spotify.lib)
-    def test_find_folder_indexes_without_start(
-        self, playlist_lib_mock, lib_mock
-    ):
+    def test_find_folder_indexes_without_start(self, playlist_lib_mock, lib_mock):
 
         sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
         playlist = spotify.Playlist(self.session, sp_playlist=sp_playlist)
@@ -1204,9 +1150,7 @@ class PlaylistContainerTest(unittest.TestCase):
 
         playlist_container.move_playlist(5, 5)
 
-        self.assertEqual(
-            lib_mock.sp_playlistcontainer_move_playlist.call_count, 0
-        )
+        self.assertEqual(lib_mock.sp_playlistcontainer_move_playlist.call_count, 0)
 
     @mock.patch('spotify.User', spec=spotify.User)
     def test_owner(self, user_mock, lib_mock):
@@ -1220,19 +1164,13 @@ class PlaylistContainerTest(unittest.TestCase):
 
         result = playlist_container.owner
 
-        lib_mock.sp_playlistcontainer_owner.assert_called_with(
-            sp_playlistcontainer
-        )
-        user_mock.assert_called_with(
-            self.session, sp_user=sp_user, add_ref=True
-        )
+        lib_mock.sp_playlistcontainer_owner.assert_called_with(sp_playlistcontainer)
+        user_mock.assert_called_with(self.session, sp_user=sp_user, add_ref=True)
         self.assertEqual(result, mock.sentinel.user)
 
     @mock.patch('spotify.playlist.lib', spec=spotify.lib)
     @mock.patch('spotify.playlist_unseen_tracks.lib', spec=spotify.lib)
-    def test_get_unseen_tracks(
-        self, unseen_lib_mock, playlist_lib_mock, lib_mock
-    ):
+    def test_get_unseen_tracks(self, unseen_lib_mock, playlist_lib_mock, lib_mock):
 
         sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
         playlist_container = spotify.PlaylistContainer(
@@ -1327,9 +1265,7 @@ class PlaylistContainerTest(unittest.TestCase):
         self.assertNotIn(playlist_container, self.session._emitters)
 
 
-@unittest.skipIf(
-    'TRAVIS' in os.environ, 'Crashes on Travis trusty with Python 3.5.0'
-)
+@unittest.skipIf('TRAVIS' in os.environ, 'Crashes on Travis trusty with Python 3.5.0')
 @mock.patch('spotify.playlist_container.lib', spec=spotify.lib)
 class PlaylistContainerCallbacksTest(unittest.TestCase):
     def setUp(self):
@@ -1347,9 +1283,7 @@ class PlaylistContainerCallbacksTest(unittest.TestCase):
         playlist_container = spotify.PlaylistContainer._cached(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
-        playlist_container.on(
-            spotify.PlaylistContainerEvent.PLAYLIST_ADDED, callback
-        )
+        playlist_container.on(spotify.PlaylistContainerEvent.PLAYLIST_ADDED, callback)
 
         _PlaylistContainerCallbacks.playlist_added(
             sp_playlistcontainer, sp_playlist, 7, spotify.ffi.NULL
@@ -1368,9 +1302,7 @@ class PlaylistContainerCallbacksTest(unittest.TestCase):
         playlist_container = spotify.PlaylistContainer._cached(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
-        playlist_container.on(
-            spotify.PlaylistContainerEvent.PLAYLIST_REMOVED, callback
-        )
+        playlist_container.on(spotify.PlaylistContainerEvent.PLAYLIST_REMOVED, callback)
 
         _PlaylistContainerCallbacks.playlist_removed(
             sp_playlistcontainer, sp_playlist, 7, spotify.ffi.NULL
@@ -1389,9 +1321,7 @@ class PlaylistContainerCallbacksTest(unittest.TestCase):
         playlist_container = spotify.PlaylistContainer._cached(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
-        playlist_container.on(
-            spotify.PlaylistContainerEvent.PLAYLIST_MOVED, callback
-        )
+        playlist_container.on(spotify.PlaylistContainerEvent.PLAYLIST_MOVED, callback)
 
         _PlaylistContainerCallbacks.playlist_moved(
             sp_playlistcontainer, sp_playlist, 7, 13, spotify.ffi.NULL
@@ -1408,9 +1338,7 @@ class PlaylistContainerCallbacksTest(unittest.TestCase):
         playlist_container = spotify.PlaylistContainer._cached(
             self.session, sp_playlistcontainer=sp_playlistcontainer
         )
-        playlist_container.on(
-            spotify.PlaylistContainerEvent.CONTAINER_LOADED, callback
-        )
+        playlist_container.on(spotify.PlaylistContainerEvent.CONTAINER_LOADED, callback)
 
         _PlaylistContainerCallbacks.container_loaded(
             sp_playlistcontainer, spotify.ffi.NULL

--- a/tests/test_playlist_track.py
+++ b/tests/test_playlist_track.py
@@ -84,9 +84,7 @@ class PlaylistTrackTest(unittest.TestCase):
 
         result = playlist_track.create_time
 
-        lib_mock.sp_playlist_track_create_time.assert_called_with(
-            sp_playlist, 0
-        )
+        lib_mock.sp_playlist_track_create_time.assert_called_with(sp_playlist, 0)
         self.assertEqual(result, 1234567890)
 
     @mock.patch('spotify.user.lib', spec=spotify.lib)
@@ -114,17 +112,13 @@ class PlaylistTrackTest(unittest.TestCase):
         self.assertEqual(result, False)
 
     def test_set_seen(self, lib_mock):
-        lib_mock.sp_playlist_track_set_seen.return_value = int(
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_playlist_track_set_seen.return_value = int(spotify.ErrorType.OK)
         sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
         playlist_track = spotify.PlaylistTrack(self.session, sp_playlist, 0)
 
         playlist_track.seen = True
 
-        lib_mock.sp_playlist_track_set_seen.assert_called_with(
-            sp_playlist, 0, 1
-        )
+        lib_mock.sp_playlist_track_set_seen.assert_called_with(sp_playlist, 0, 1)
 
     def test_set_seen_fails_if_error(self, lib_mock):
         lib_mock.sp_playlist_track_set_seen.return_value = int(

--- a/tests/test_playlist_track.py
+++ b/tests/test_playlist_track.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-
 import tests
 from tests import mock
 

--- a/tests/test_playlist_track.py
+++ b/tests/test_playlist_track.py
@@ -7,16 +7,16 @@ import tests
 from tests import mock
 
 
-@mock.patch('spotify.playlist_track.lib', spec=spotify.lib)
+@mock.patch("spotify.playlist_track.lib", spec=spotify.lib)
 class PlaylistTrackTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_track(self, track_lib_mock, lib_mock):
-        sp_track = spotify.ffi.cast('sp_track *', 43)
+        sp_track = spotify.ffi.cast("sp_track *", 43)
         lib_mock.sp_playlist_track.return_value = sp_track
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist_track = spotify.PlaylistTrack(self.session, sp_playlist, 0)
 
         result = playlist_track.track
@@ -26,41 +26,41 @@ class PlaylistTrackTest(unittest.TestCase):
         self.assertIsInstance(result, spotify.Track)
         self.assertEqual(result._sp_track, sp_track)
 
-    @mock.patch('spotify.Track', spec=spotify.Track)
-    @mock.patch('spotify.User', spec=spotify.User)
+    @mock.patch("spotify.Track", spec=spotify.Track)
+    @mock.patch("spotify.User", spec=spotify.User)
     def test_repr(self, user_mock, track_mock, lib_mock):
-        sp_track = spotify.ffi.cast('sp_track *', 43)
+        sp_track = spotify.ffi.cast("sp_track *", 43)
         lib_mock.sp_playlist_track.return_value = sp_track
         track_instance_mock = track_mock.return_value
-        track_instance_mock.link.uri = 'foo'
+        track_instance_mock.link.uri = "foo"
 
         lib_mock.sp_playlist_track_create_time.return_value = 1234567890
 
-        sp_user = spotify.ffi.cast('sp_user *', 44)
+        sp_user = spotify.ffi.cast("sp_user *", 44)
         lib_mock.sp_playlist_track_creator.return_value = sp_user
-        user_mock.return_value = 'alice-user-object'
+        user_mock.return_value = "alice-user-object"
 
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist_track = spotify.PlaylistTrack(self.session, sp_playlist, 0)
 
         result = repr(playlist_track)
 
         self.assertEqual(
             result,
-            'PlaylistTrack(uri=%r, creator=%r, create_time=%d)'
-            % ('foo', 'alice-user-object', 1234567890),
+            "PlaylistTrack(uri=%r, creator=%r, create_time=%d)"
+            % ("foo", "alice-user-object", 1234567890),
         )
 
     def test_eq(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         track1 = spotify.PlaylistTrack(self.session, sp_playlist, 0)
         track2 = spotify.PlaylistTrack(self.session, sp_playlist, 0)
 
         self.assertTrue(track1 == track2)
-        self.assertFalse(track1 == 'foo')
+        self.assertFalse(track1 == "foo")
 
     def test_ne(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         track1 = spotify.PlaylistTrack(self.session, sp_playlist, 0)
         track2 = spotify.PlaylistTrack(self.session, sp_playlist, 0)
         track3 = spotify.PlaylistTrack(self.session, sp_playlist, 1)
@@ -69,7 +69,7 @@ class PlaylistTrackTest(unittest.TestCase):
         self.assertTrue(track1 != track3)
 
     def test_hash(self, lib_mock):
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         track1 = spotify.PlaylistTrack(self.session, sp_playlist, 0)
         track2 = spotify.PlaylistTrack(self.session, sp_playlist, 0)
         track3 = spotify.PlaylistTrack(self.session, sp_playlist, 1)
@@ -79,7 +79,7 @@ class PlaylistTrackTest(unittest.TestCase):
 
     def test_create_time(self, lib_mock):
         lib_mock.sp_playlist_track_create_time.return_value = 1234567890
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist_track = spotify.PlaylistTrack(self.session, sp_playlist, 0)
 
         result = playlist_track.create_time
@@ -87,11 +87,11 @@ class PlaylistTrackTest(unittest.TestCase):
         lib_mock.sp_playlist_track_create_time.assert_called_with(sp_playlist, 0)
         self.assertEqual(result, 1234567890)
 
-    @mock.patch('spotify.user.lib', spec=spotify.lib)
+    @mock.patch("spotify.user.lib", spec=spotify.lib)
     def test_creator(self, user_lib_mock, lib_mock):
-        sp_user = spotify.ffi.cast('sp_user *', 43)
+        sp_user = spotify.ffi.cast("sp_user *", 43)
         lib_mock.sp_playlist_track_creator.return_value = sp_user
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist_track = spotify.PlaylistTrack(self.session, sp_playlist, 0)
 
         result = playlist_track.creator
@@ -103,7 +103,7 @@ class PlaylistTrackTest(unittest.TestCase):
 
     def test_is_seen(self, lib_mock):
         lib_mock.sp_playlist_track_seen.return_value = 0
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist_track = spotify.PlaylistTrack(self.session, sp_playlist, 0)
 
         result = playlist_track.seen
@@ -113,7 +113,7 @@ class PlaylistTrackTest(unittest.TestCase):
 
     def test_set_seen(self, lib_mock):
         lib_mock.sp_playlist_track_set_seen.return_value = int(spotify.ErrorType.OK)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist_track = spotify.PlaylistTrack(self.session, sp_playlist, 0)
 
         playlist_track.seen = True
@@ -124,7 +124,7 @@ class PlaylistTrackTest(unittest.TestCase):
         lib_mock.sp_playlist_track_set_seen.return_value = int(
             spotify.ErrorType.BAD_API_VERSION
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist_track = spotify.PlaylistTrack(self.session, sp_playlist, 0)
 
         with self.assertRaises(spotify.Error):
@@ -132,19 +132,19 @@ class PlaylistTrackTest(unittest.TestCase):
 
     def test_message(self, lib_mock):
         lib_mock.sp_playlist_track_message.return_value = spotify.ffi.new(
-            'char[]', b'foo bar'
+            "char[]", b"foo bar"
         )
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist_track = spotify.PlaylistTrack(self.session, sp_playlist, 0)
 
         result = playlist_track.message
 
         lib_mock.sp_playlist_track_message.assert_called_with(sp_playlist, 0)
-        self.assertEqual(result, 'foo bar')
+        self.assertEqual(result, "foo bar")
 
     def test_message_is_none_when_null(self, lib_mock):
         lib_mock.sp_playlist_track_message.return_value = spotify.ffi.NULL
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 42)
         playlist_track = spotify.PlaylistTrack(self.session, sp_playlist, 0)
 
         result = playlist_track.message

--- a/tests/test_playlist_unseen_tracks.py
+++ b/tests/test_playlist_unseen_tracks.py
@@ -7,7 +7,7 @@ import tests
 from tests import mock
 
 
-@mock.patch('spotify.playlist_unseen_tracks.lib', spec=spotify.lib)
+@mock.patch("spotify.playlist_unseen_tracks.lib", spec=spotify.lib)
 class PlaylistUnseenTracksTest(unittest.TestCase):
 
     # TODO Test that the collection releases sp_playlistcontainer and
@@ -16,14 +16,14 @@ class PlaylistUnseenTracksTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_normal_usage(self, track_lib_mock, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
 
         total_num_tracks = 3
         sp_tracks = [
-            spotify.ffi.cast('sp_track *', 44 + i) for i in range(total_num_tracks)
+            spotify.ffi.cast("sp_track *", 44 + i) for i in range(total_num_tracks)
         ]
 
         def func(sp_pc, sp_p, sp_t, num_t):
@@ -69,8 +69,8 @@ class PlaylistUnseenTracksTest(unittest.TestCase):
         self.assertEqual(lib_mock.sp_playlistcontainer_get_unseen_tracks.call_count, 2)
 
     def test_raises_error_on_failure(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_get_unseen_tracks.return_value = -3
 
         with self.assertRaises(spotify.Error):
@@ -78,14 +78,14 @@ class PlaylistUnseenTracksTest(unittest.TestCase):
                 self.session, sp_playlistcontainer, sp_playlist
             )
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_getitem_with_slice(self, track_lib_mock, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
 
         total_num_tracks = 3
         sp_tracks = [
-            spotify.ffi.cast('sp_track *', 44 + i) for i in range(total_num_tracks)
+            spotify.ffi.cast("sp_track *", 44 + i) for i in range(total_num_tracks)
         ]
 
         def func(sp_pc, sp_p, sp_t, num_t):
@@ -110,8 +110,8 @@ class PlaylistUnseenTracksTest(unittest.TestCase):
         self.assertEqual(result[1]._sp_track, sp_tracks[1])
 
     def test_getitem_raises_index_error_on_too_low_index(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_get_unseen_tracks.return_value = 0
         tracks = spotify.PlaylistUnseenTracks(
             self.session, sp_playlistcontainer, sp_playlist
@@ -120,11 +120,11 @@ class PlaylistUnseenTracksTest(unittest.TestCase):
         with self.assertRaises(IndexError) as ctx:
             tracks[-1]
 
-        self.assertEqual(str(ctx.exception), 'list index out of range')
+        self.assertEqual(str(ctx.exception), "list index out of range")
 
     def test_getitem_raises_index_error_on_too_high_index(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_get_unseen_tracks.return_value = 0
         tracks = spotify.PlaylistUnseenTracks(
             self.session, sp_playlistcontainer, sp_playlist
@@ -133,25 +133,25 @@ class PlaylistUnseenTracksTest(unittest.TestCase):
         with self.assertRaises(IndexError) as ctx:
             tracks[1]
 
-        self.assertEqual(str(ctx.exception), 'list index out of range')
+        self.assertEqual(str(ctx.exception), "list index out of range")
 
     def test_getitem_raises_type_error_on_non_integral_index(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_get_unseen_tracks.return_value = 0
         tracks = spotify.PlaylistUnseenTracks(
             self.session, sp_playlistcontainer, sp_playlist
         )
 
         with self.assertRaises(TypeError):
-            tracks['abc']
+            tracks["abc"]
 
     def test_repr(self, lib_mock):
-        sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
-        sp_playlist = spotify.ffi.cast('sp_playlist *', 43)
+        sp_playlistcontainer = spotify.ffi.cast("sp_playlistcontainer *", 42)
+        sp_playlist = spotify.ffi.cast("sp_playlist *", 43)
         lib_mock.sp_playlistcontainer_get_unseen_tracks.return_value = 0
         tracks = spotify.PlaylistUnseenTracks(
             self.session, sp_playlistcontainer, sp_playlist
         )
 
-        self.assertEqual(repr(tracks), 'PlaylistUnseenTracks([])')
+        self.assertEqual(repr(tracks), "PlaylistUnseenTracks([])")

--- a/tests/test_playlist_unseen_tracks.py
+++ b/tests/test_playlist_unseen_tracks.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-
 import tests
 from tests import mock
 

--- a/tests/test_playlist_unseen_tracks.py
+++ b/tests/test_playlist_unseen_tracks.py
@@ -23,8 +23,7 @@ class PlaylistUnseenTracksTest(unittest.TestCase):
 
         total_num_tracks = 3
         sp_tracks = [
-            spotify.ffi.cast('sp_track *', 44 + i)
-            for i in range(total_num_tracks)
+            spotify.ffi.cast('sp_track *', 44 + i) for i in range(total_num_tracks)
         ]
 
         def func(sp_pc, sp_p, sp_t, num_t):
@@ -39,25 +38,19 @@ class PlaylistUnseenTracksTest(unittest.TestCase):
         )
 
         # Collection keeps references to container and playlist:
-        lib_mock.sp_playlistcontainer_add_ref.assert_called_with(
-            sp_playlistcontainer
-        )
+        lib_mock.sp_playlistcontainer_add_ref.assert_called_with(sp_playlistcontainer)
         lib_mock.sp_playlist_add_ref.assert_called_with(sp_playlist)
 
         # Getting collection and length causes no tracks to be retrieved:
         self.assertEqual(len(tracks), total_num_tracks)
-        self.assertEqual(
-            lib_mock.sp_playlistcontainer_get_unseen_tracks.call_count, 1
-        )
+        self.assertEqual(lib_mock.sp_playlistcontainer_get_unseen_tracks.call_count, 1)
         lib_mock.sp_playlistcontainer_get_unseen_tracks.assert_called_with(
             sp_playlistcontainer, sp_playlist, mock.ANY, 0
         )
 
         # Getting items causes more tracks to be retrieved:
         track0 = tracks[0]
-        self.assertEqual(
-            lib_mock.sp_playlistcontainer_get_unseen_tracks.call_count, 2
-        )
+        self.assertEqual(lib_mock.sp_playlistcontainer_get_unseen_tracks.call_count, 2)
         lib_mock.sp_playlistcontainer_get_unseen_tracks.assert_called_with(
             sp_playlistcontainer, sp_playlist, mock.ANY, total_num_tracks
         )
@@ -66,18 +59,14 @@ class PlaylistUnseenTracksTest(unittest.TestCase):
 
         # Getting already retrieved tracks causes no new retrieval:
         track1 = tracks[1]
-        self.assertEqual(
-            lib_mock.sp_playlistcontainer_get_unseen_tracks.call_count, 2
-        )
+        self.assertEqual(lib_mock.sp_playlistcontainer_get_unseen_tracks.call_count, 2)
         self.assertIsInstance(track1, spotify.Track)
         self.assertEqual(track1._sp_track, sp_tracks[1])
 
         # Getting item with negative index
         track2 = tracks[-3]
         self.assertEqual(track2._sp_track, track0._sp_track)
-        self.assertEqual(
-            lib_mock.sp_playlistcontainer_get_unseen_tracks.call_count, 2
-        )
+        self.assertEqual(lib_mock.sp_playlistcontainer_get_unseen_tracks.call_count, 2)
 
     def test_raises_error_on_failure(self, lib_mock):
         sp_playlistcontainer = spotify.ffi.cast('sp_playlistcontainer *', 42)
@@ -96,8 +85,7 @@ class PlaylistUnseenTracksTest(unittest.TestCase):
 
         total_num_tracks = 3
         sp_tracks = [
-            spotify.ffi.cast('sp_track *', 44 + i)
-            for i in range(total_num_tracks)
+            spotify.ffi.cast('sp_track *', 44 + i) for i in range(total_num_tracks)
         ]
 
         def func(sp_pc, sp_p, sp_t, num_t):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-
 import tests
 from tests import mock
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -7,7 +7,7 @@ import tests
 from tests import mock
 
 
-@mock.patch('spotify.search.lib', spec=spotify.lib)
+@mock.patch("spotify.search.lib", spec=spotify.lib)
 class SearchTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
@@ -18,7 +18,7 @@ class SearchTest(unittest.TestCase):
 
     def assert_fails_if_error(self, lib_mock, func):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.BAD_API_VERSION
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         with self.assertRaises(spotify.Error):
@@ -29,10 +29,10 @@ class SearchTest(unittest.TestCase):
             spotify.Search(self.session)
 
     def test_search(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         lib_mock.sp_search_create.return_value = sp_search
 
-        result = spotify.Search(self.session, query='alice')
+        result = spotify.Search(self.session, query="alice")
 
         lib_mock.sp_search_create.assert_called_with(
             self.session._sp_session,
@@ -51,7 +51,7 @@ class SearchTest(unittest.TestCase):
         )
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_search_create.call_args[0][1]),
-            b'alice',
+            b"alice",
         )
         self.assertEqual(lib_mock.sp_search_add_ref.call_count, 0)
         self.assertIsInstance(result, spotify.Search)
@@ -63,11 +63,11 @@ class SearchTest(unittest.TestCase):
         self.assertTrue(result.loaded_event.wait(3))
 
     def test_search_with_callback(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         lib_mock.sp_search_create.return_value = sp_search
         callback = mock.Mock()
 
-        result = spotify.Search(self.session, query='alice', callback=callback)
+        result = spotify.Search(self.session, query="alice", callback=callback)
 
         search_complete_cb = lib_mock.sp_search_create.call_args[0][11]
         userdata = lib_mock.sp_search_create.call_args[0][12]
@@ -78,11 +78,11 @@ class SearchTest(unittest.TestCase):
 
     def test_search_where_result_is_gone_before_callback_is_called(self, lib_mock):
 
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         lib_mock.sp_search_create.return_value = sp_search
         callback = mock.Mock()
 
-        result = spotify.Search(self.session, query='alice', callback=callback)
+        result = spotify.Search(self.session, query="alice", callback=callback)
         loaded_event = result.loaded_event
         result = None  # noqa
         tests.gc_collect()
@@ -98,14 +98,14 @@ class SearchTest(unittest.TestCase):
         self.assertEqual(callback.call_args[0][0]._sp_search, sp_search)
 
     def test_adds_ref_to_sp_search_when_created(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
 
         spotify.Search(self.session, sp_search=sp_search)
 
         lib_mock.sp_search_add_ref.assert_called_with(sp_search)
 
     def test_releases_sp_search_when_search_dies(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
 
         search = spotify.Search(self.session, sp_search=sp_search)
         search = None  # noqa
@@ -114,39 +114,39 @@ class SearchTest(unittest.TestCase):
         lib_mock.sp_search_release.assert_called_with(sp_search)
 
     def test_loaded_event_is_unset_by_default(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         self.assertFalse(search.loaded_event.is_set())
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_repr(self, link_mock, lib_mock):
         link_instance_mock = link_mock.return_value
-        link_instance_mock.uri = 'foo'
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        link_instance_mock.uri = "foo"
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = repr(search)
 
-        self.assertEqual(result, 'Search(%r)' % 'foo')
+        self.assertEqual(result, "Search(%r)" % "foo")
 
     def test_eq(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search1 = spotify.Search(self.session, sp_search=sp_search)
         search2 = spotify.Search(self.session, sp_search=sp_search)
 
         self.assertTrue(search1 == search2)
-        self.assertFalse(search1 == 'foo')
+        self.assertFalse(search1 == "foo")
 
     def test_ne(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search1 = spotify.Search(self.session, sp_search=sp_search)
         search2 = spotify.Search(self.session, sp_search=sp_search)
 
         self.assertFalse(search1 != search2)
 
     def test_hash(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search1 = spotify.Search(self.session, sp_search=sp_search)
         search2 = spotify.Search(self.session, sp_search=sp_search)
 
@@ -154,7 +154,7 @@ class SearchTest(unittest.TestCase):
 
     def test_is_loaded(self, lib_mock):
         lib_mock.sp_search_is_loaded.return_value = 1
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.is_loaded
@@ -164,7 +164,7 @@ class SearchTest(unittest.TestCase):
 
     def test_error(self, lib_mock):
         lib_mock.sp_search_error.return_value = int(spotify.ErrorType.IS_LOADING)
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.error
@@ -172,22 +172,22 @@ class SearchTest(unittest.TestCase):
         lib_mock.sp_search_error.assert_called_once_with(sp_search)
         self.assertIs(result, spotify.ErrorType.IS_LOADING)
 
-    @mock.patch('spotify.utils.load')
+    @mock.patch("spotify.utils.load")
     def test_load(self, load_mock, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         search.load(10)
 
         load_mock.assert_called_with(self.session, search, timeout=10)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_tracks(self, track_lib_mock, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
-        sp_track = spotify.ffi.cast('sp_track *', 43)
+        sp_track = spotify.ffi.cast("sp_track *", 43)
         lib_mock.sp_search_num_tracks.return_value = 1
         lib_mock.sp_search_track.return_value = sp_track
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         self.assertEqual(lib_mock.sp_search_add_ref.call_count, 1)
@@ -207,7 +207,7 @@ class SearchTest(unittest.TestCase):
     def test_tracks_if_no_tracks(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_search_num_tracks.return_value = 0
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.tracks
@@ -219,7 +219,7 @@ class SearchTest(unittest.TestCase):
     def test_tracks_if_unloaded(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_search_is_loaded.return_value = 0
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.tracks
@@ -230,13 +230,13 @@ class SearchTest(unittest.TestCase):
     def test_tracks_fails_if_error(self, lib_mock):
         self.assert_fails_if_error(lib_mock, lambda s: s.tracks)
 
-    @mock.patch('spotify.album.lib', spec=spotify.lib)
+    @mock.patch("spotify.album.lib", spec=spotify.lib)
     def test_albums(self, album_lib_mock, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
-        sp_album = spotify.ffi.cast('sp_album *', 43)
+        sp_album = spotify.ffi.cast("sp_album *", 43)
         lib_mock.sp_search_num_albums.return_value = 1
         lib_mock.sp_search_album.return_value = sp_album
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         self.assertEqual(lib_mock.sp_search_add_ref.call_count, 1)
@@ -256,7 +256,7 @@ class SearchTest(unittest.TestCase):
     def test_albums_if_no_albums(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_search_num_albums.return_value = 0
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.albums
@@ -268,7 +268,7 @@ class SearchTest(unittest.TestCase):
     def test_albums_if_unloaded(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_search_is_loaded.return_value = 0
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.albums
@@ -279,13 +279,13 @@ class SearchTest(unittest.TestCase):
     def test_albums_fails_if_error(self, lib_mock):
         self.assert_fails_if_error(lib_mock, lambda s: s.albums)
 
-    @mock.patch('spotify.artist.lib', spec=spotify.lib)
+    @mock.patch("spotify.artist.lib", spec=spotify.lib)
     def test_artists(self, artist_lib_mock, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
-        sp_artist = spotify.ffi.cast('sp_artist *', 43)
+        sp_artist = spotify.ffi.cast("sp_artist *", 43)
         lib_mock.sp_search_num_artists.return_value = 1
         lib_mock.sp_search_artist.return_value = sp_artist
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         self.assertEqual(lib_mock.sp_search_add_ref.call_count, 1)
@@ -305,7 +305,7 @@ class SearchTest(unittest.TestCase):
     def test_artists_if_no_artists(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_search_num_artists.return_value = 0
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.artists
@@ -317,7 +317,7 @@ class SearchTest(unittest.TestCase):
     def test_artists_if_unloaded(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_search_is_loaded.return_value = 0
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.artists
@@ -328,20 +328,20 @@ class SearchTest(unittest.TestCase):
     def test_artists_fails_if_error(self, lib_mock):
         self.assert_fails_if_error(lib_mock, lambda s: s.artists)
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_playlists(self, playlist_lib_mock, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_search_num_playlists.return_value = 1
         lib_mock.sp_search_playlist_name.return_value = spotify.ffi.new(
-            'char[]', b'The Party List'
+            "char[]", b"The Party List"
         )
         lib_mock.sp_search_playlist_uri.return_value = spotify.ffi.new(
-            'char[]', b'spotify:playlist:foo'
+            "char[]", b"spotify:playlist:foo"
         )
         lib_mock.sp_search_playlist_image_uri.return_value = spotify.ffi.new(
-            'char[]', b'spotify:image:foo'
+            "char[]", b"spotify:image:foo"
         )
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         self.assertEqual(lib_mock.sp_search_add_ref.call_count, 1)
@@ -353,9 +353,9 @@ class SearchTest(unittest.TestCase):
 
         item = result[0]
         self.assertIsInstance(item, spotify.SearchPlaylist)
-        self.assertEqual(item.name, 'The Party List')
-        self.assertEqual(item.uri, 'spotify:playlist:foo')
-        self.assertEqual(item.image_uri, 'spotify:image:foo')
+        self.assertEqual(item.name, "The Party List")
+        self.assertEqual(item.uri, "spotify:playlist:foo")
+        self.assertEqual(item.image_uri, "spotify:image:foo")
         self.assertEqual(lib_mock.sp_search_playlist_name.call_count, 1)
         lib_mock.sp_search_playlist_name.assert_called_with(sp_search, 0)
         self.assertEqual(lib_mock.sp_search_playlist_uri.call_count, 1)
@@ -366,7 +366,7 @@ class SearchTest(unittest.TestCase):
     def test_playlists_if_no_playlists(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_search_num_playlists.return_value = 0
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.playlists
@@ -378,7 +378,7 @@ class SearchTest(unittest.TestCase):
     def test_playlists_if_unloaded(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_search_is_loaded.return_value = 0
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.playlists
@@ -392,20 +392,20 @@ class SearchTest(unittest.TestCase):
     def test_query(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_search_query.return_value = spotify.ffi.new(
-            'char[]', b'Foo Bar Baz'
+            "char[]", b"Foo Bar Baz"
         )
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.query
 
         lib_mock.sp_search_query.assert_called_once_with(sp_search)
-        self.assertEqual(result, 'Foo Bar Baz')
+        self.assertEqual(result, "Foo Bar Baz")
 
     def test_query_is_none_if_empty(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
-        lib_mock.sp_search_query.return_value = spotify.ffi.new('char[]', b'')
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        lib_mock.sp_search_query.return_value = spotify.ffi.new("char[]", b"")
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.query
@@ -419,20 +419,20 @@ class SearchTest(unittest.TestCase):
     def test_did_you_mean(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_search_did_you_mean.return_value = spotify.ffi.new(
-            'char[]', b'Foo Bar Baz'
+            "char[]", b"Foo Bar Baz"
         )
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.did_you_mean
 
         lib_mock.sp_search_did_you_mean.assert_called_once_with(sp_search)
-        self.assertEqual(result, 'Foo Bar Baz')
+        self.assertEqual(result, "Foo Bar Baz")
 
     def test_did_you_mean_is_none_if_empty(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
-        lib_mock.sp_search_did_you_mean.return_value = spotify.ffi.new('char[]', b'')
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        lib_mock.sp_search_did_you_mean.return_value = spotify.ffi.new("char[]", b"")
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.did_you_mean
@@ -446,7 +446,7 @@ class SearchTest(unittest.TestCase):
     def test_track_total(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_search_total_tracks.return_value = 75
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.track_total
@@ -460,7 +460,7 @@ class SearchTest(unittest.TestCase):
     def test_album_total(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_search_total_albums.return_value = 75
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.album_total
@@ -474,7 +474,7 @@ class SearchTest(unittest.TestCase):
     def test_artist_total(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_search_total_artists.return_value = 75
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.artist_total
@@ -488,7 +488,7 @@ class SearchTest(unittest.TestCase):
     def test_playlist_total(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_search_total_playlists.return_value = 75
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.playlist_total
@@ -500,7 +500,7 @@ class SearchTest(unittest.TestCase):
         self.assert_fails_if_error(lib_mock, lambda s: s.playlist_total)
 
     def test_search_type_defaults_to_standard(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
         result = search.search_type
@@ -508,13 +508,13 @@ class SearchTest(unittest.TestCase):
         self.assertEqual(result, spotify.SearchType.STANDARD)
 
     def test_more(self, lib_mock):
-        sp_search1 = spotify.ffi.cast('sp_search *', 42)
-        sp_search2 = spotify.ffi.cast('sp_search *', 43)
+        sp_search1 = spotify.ffi.cast("sp_search *", 42)
+        sp_search2 = spotify.ffi.cast("sp_search *", 43)
         lib_mock.sp_search_create.side_effect = [sp_search1, sp_search2]
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
-        lib_mock.sp_search_query.return_value = spotify.ffi.new('char[]', b'alice')
+        lib_mock.sp_search_query.return_value = spotify.ffi.new("char[]", b"alice")
 
-        result = spotify.Search(self.session, query='alice')
+        result = spotify.Search(self.session, query="alice")
 
         lib_mock.sp_search_create.assert_called_with(
             self.session._sp_session,
@@ -533,7 +533,7 @@ class SearchTest(unittest.TestCase):
         )
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_search_create.call_args[0][1]),
-            b'alice',
+            b"alice",
         )
         self.assertEqual(lib_mock.sp_search_add_ref.call_count, 0)
         self.assertIsInstance(result, spotify.Search)
@@ -560,17 +560,17 @@ class SearchTest(unittest.TestCase):
         )
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_search_create.call_args[0][1]),
-            b'alice',
+            b"alice",
         )
         self.assertEqual(lib_mock.sp_search_add_ref.call_count, 0)
         self.assertIsInstance(result, spotify.Search)
         self.assertEqual(result._sp_search, sp_search2)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_link_creates_link_to_search(self, link_mock, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         search = spotify.Search(self.session, sp_search=sp_search)
-        sp_link = spotify.ffi.cast('sp_link *', 43)
+        sp_link = spotify.ffi.cast("sp_link *", 43)
         lib_mock.sp_link_create_from_search.return_value = sp_link
         link_mock.return_value = mock.sentinel.link
 
@@ -586,26 +586,26 @@ class SearchPlaylistTest(unittest.TestCase):
 
     def test_attributes(self):
         pl = spotify.SearchPlaylist(
-            self.session, name='foo', uri='uri:foo', image_uri='image:foo'
+            self.session, name="foo", uri="uri:foo", image_uri="image:foo"
         )
 
-        self.assertEqual(pl.name, 'foo')
-        self.assertEqual(pl.uri, 'uri:foo')
-        self.assertEqual(pl.image_uri, 'image:foo')
+        self.assertEqual(pl.name, "foo")
+        self.assertEqual(pl.uri, "uri:foo")
+        self.assertEqual(pl.image_uri, "image:foo")
 
     def test_repr(self):
         pl = spotify.SearchPlaylist(
-            self.session, name='foo', uri='uri:foo', image_uri='image:foo'
+            self.session, name="foo", uri="uri:foo", image_uri="image:foo"
         )
 
         result = repr(pl)
 
-        self.assertEqual(result, 'SearchPlaylist(name=%r, uri=%r)' % ('foo', 'uri:foo'))
+        self.assertEqual(result, "SearchPlaylist(name=%r, uri=%r)" % ("foo", "uri:foo"))
 
     def test_playlist(self):
         self.session.get_playlist.return_value = mock.sentinel.playlist
         pl = spotify.SearchPlaylist(
-            self.session, name='foo', uri='uri:foo', image_uri='image:foo'
+            self.session, name="foo", uri="uri:foo", image_uri="image:foo"
         )
 
         result = pl.playlist
@@ -616,7 +616,7 @@ class SearchPlaylistTest(unittest.TestCase):
     def test_image(self):
         self.session.get_image.return_value = mock.sentinel.image
         pl = spotify.SearchPlaylist(
-            self.session, name='foo', uri='uri:foo', image_uri='image:foo'
+            self.session, name="foo", uri="uri:foo", image_uri="image:foo"
         )
 
         result = pl.image

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -17,9 +17,7 @@ class SearchTest(unittest.TestCase):
         spotify._session_instance = None
 
     def assert_fails_if_error(self, lib_mock, func):
-        lib_mock.sp_search_error.return_value = (
-            spotify.ErrorType.BAD_API_VERSION
-        )
+        lib_mock.sp_search_error.return_value = spotify.ErrorType.BAD_API_VERSION
         sp_search = spotify.ffi.cast('sp_search *', 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
@@ -78,9 +76,7 @@ class SearchTest(unittest.TestCase):
         result.loaded_event.wait(3)
         callback.assert_called_with(result)
 
-    def test_search_where_result_is_gone_before_callback_is_called(
-        self, lib_mock
-    ):
+    def test_search_where_result_is_gone_before_callback_is_called(self, lib_mock):
 
         sp_search = spotify.ffi.cast('sp_search *', 42)
         lib_mock.sp_search_create.return_value = sp_search
@@ -167,9 +163,7 @@ class SearchTest(unittest.TestCase):
         self.assertTrue(result)
 
     def test_error(self, lib_mock):
-        lib_mock.sp_search_error.return_value = int(
-            spotify.ErrorType.IS_LOADING
-        )
+        lib_mock.sp_search_error.return_value = int(spotify.ErrorType.IS_LOADING)
         sp_search = spotify.ffi.cast('sp_search *', 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
@@ -437,9 +431,7 @@ class SearchTest(unittest.TestCase):
 
     def test_did_you_mean_is_none_if_empty(self, lib_mock):
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
-        lib_mock.sp_search_did_you_mean.return_value = spotify.ffi.new(
-            'char[]', b''
-        )
+        lib_mock.sp_search_did_you_mean.return_value = spotify.ffi.new('char[]', b'')
         sp_search = spotify.ffi.cast('sp_search *', 42)
         search = spotify.Search(self.session, sp_search=sp_search)
 
@@ -520,9 +512,7 @@ class SearchTest(unittest.TestCase):
         sp_search2 = spotify.ffi.cast('sp_search *', 43)
         lib_mock.sp_search_create.side_effect = [sp_search1, sp_search2]
         lib_mock.sp_search_error.return_value = spotify.ErrorType.OK
-        lib_mock.sp_search_query.return_value = spotify.ffi.new(
-            'char[]', b'alice'
-        )
+        lib_mock.sp_search_query.return_value = spotify.ffi.new('char[]', b'alice')
 
         result = spotify.Search(self.session, query='alice')
 
@@ -586,9 +576,7 @@ class SearchTest(unittest.TestCase):
 
         result = search.link
 
-        link_mock.assert_called_once_with(
-            self.session, sp_link=sp_link, add_ref=False
-        )
+        link_mock.assert_called_once_with(self.session, sp_link=sp_link, add_ref=False)
         self.assertEqual(result, mock.sentinel.link)
 
 
@@ -612,9 +600,7 @@ class SearchPlaylistTest(unittest.TestCase):
 
         result = repr(pl)
 
-        self.assertEqual(
-            result, 'SearchPlaylist(name=%r, uri=%r)' % ('foo', 'uri:foo')
-        )
+        self.assertEqual(result, 'SearchPlaylist(name=%r, uri=%r)' % ('foo', 'uri:foo'))
 
     def test_playlist(self):
         self.session.get_playlist.return_value = mock.sentinel.playlist

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -7,9 +7,8 @@ import unittest
 import pytest
 
 import spotify
-from spotify.session import _SessionCallbacks
-
 import tests
+from spotify.session import _SessionCallbacks
 from tests import mock
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -45,9 +45,7 @@ class SessionTest(unittest.TestCase):
         config_mock.load_application_key_file.assert_called_once_with()
 
     def test_raises_error_if_not_ok(self, lib_mock):
-        lib_mock.sp_session_create.return_value = (
-            spotify.ErrorType.BAD_API_VERSION
-        )
+        lib_mock.sp_session_create.return_value = spotify.ErrorType.BAD_API_VERSION
         config = spotify.Config()
         config.application_key = b'\x01' * 321
 
@@ -141,9 +139,7 @@ class SessionTest(unittest.TestCase):
         lib_mock.sp_session_logout.assert_called_once_with(session._sp_session)
 
     def test_logout_fail_raises_error(self, lib_mock):
-        lib_mock.sp_session_login.return_value = (
-            spotify.ErrorType.BAD_API_VERSION
-        )
+        lib_mock.sp_session_login.return_value = spotify.ErrorType.BAD_API_VERSION
         session = tests.create_real_session(lib_mock)
 
         with self.assertRaises(spotify.Error):
@@ -152,9 +148,7 @@ class SessionTest(unittest.TestCase):
     def test_remembered_user_name_grows_buffer_to_fit_username(self, lib_mock):
         username = 'alice' * 100
 
-        lib_mock.sp_session_remembered_user.side_effect = tests.buffer_writer(
-            username
-        )
+        lib_mock.sp_session_remembered_user.side_effect = tests.buffer_writer(username)
         session = tests.create_real_session(lib_mock)
 
         result = session.remembered_user_name
@@ -184,9 +178,7 @@ class SessionTest(unittest.TestCase):
         lib_mock.sp_session_relogin.assert_called_once_with(session._sp_session)
 
     def test_relogin_fail_raises_error(self, lib_mock):
-        lib_mock.sp_session_relogin.return_value = (
-            spotify.ErrorType.NO_CREDENTIALS
-        )
+        lib_mock.sp_session_relogin.return_value = spotify.ErrorType.NO_CREDENTIALS
         session = tests.create_real_session(lib_mock)
 
         with self.assertRaises(spotify.Error):
@@ -201,9 +193,7 @@ class SessionTest(unittest.TestCase):
         lib_mock.sp_session_forget_me.assert_called_with(session._sp_session)
 
     def test_forget_me_fail_raises_error(self, lib_mock):
-        lib_mock.sp_session_forget_me.return_value = (
-            spotify.ErrorType.BAD_API_VERSION
-        )
+        lib_mock.sp_session_forget_me.return_value = spotify.ErrorType.BAD_API_VERSION
         session = tests.create_real_session(lib_mock)
 
         with self.assertRaises(spotify.Error):
@@ -211,9 +201,7 @@ class SessionTest(unittest.TestCase):
 
     @mock.patch('spotify.user.lib', spec=spotify.lib)
     def test_user(self, user_lib_mock, lib_mock):
-        lib_mock.sp_session_user.return_value = spotify.ffi.cast(
-            'sp_user *', 42
-        )
+        lib_mock.sp_session_user.return_value = spotify.ffi.cast('sp_user *', 42)
         session = tests.create_real_session(lib_mock)
 
         result = session.user
@@ -231,9 +219,7 @@ class SessionTest(unittest.TestCase):
         self.assertIsNone(result)
 
     def test_user_name(self, lib_mock):
-        lib_mock.sp_session_user_name.return_value = spotify.ffi.new(
-            'char[]', b'alice'
-        )
+        lib_mock.sp_session_user_name.return_value = spotify.ffi.new('char[]', b'alice')
         session = tests.create_real_session(lib_mock)
 
         result = session.user_name
@@ -262,9 +248,7 @@ class SessionTest(unittest.TestCase):
         ):
             result = session.playlist_container
 
-        lib_mock.sp_session_playlistcontainer.assert_called_with(
-            session._sp_session
-        )
+        lib_mock.sp_session_playlistcontainer.assert_called_with(session._sp_session)
         self.assertIsInstance(result, spotify.PlaylistContainer)
 
     @mock.patch('spotify.playlist_container.lib', spec=spotify.lib)
@@ -280,9 +264,7 @@ class SessionTest(unittest.TestCase):
             UserWarning, match='Spotify broke the libspotify playlists API'
         ):
             result1 = session.playlist_container
-        result1.on(
-            spotify.PlaylistContainerEvent.PLAYLIST_ADDED, lambda *args: None
-        )
+        result1.on(spotify.PlaylistContainerEvent.PLAYLIST_ADDED, lambda *args: None)
         with pytest.warns(
             UserWarning, match='Spotify broke the libspotify playlists API'
         ):
@@ -302,9 +284,7 @@ class SessionTest(unittest.TestCase):
         ):
             result = session.playlist_container
 
-        lib_mock.sp_session_playlistcontainer.assert_called_with(
-            session._sp_session
-        )
+        lib_mock.sp_session_playlistcontainer.assert_called_with(session._sp_session)
         self.assertIsNone(result)
 
     @mock.patch('spotify.playlist.lib', spec=spotify.lib)
@@ -364,9 +344,7 @@ class SessionTest(unittest.TestCase):
 
         session.flush_caches()
 
-        lib_mock.sp_session_flush_caches.assert_called_once_with(
-            session._sp_session
-        )
+        lib_mock.sp_session_flush_caches.assert_called_once_with(session._sp_session)
 
     def test_flush_caches_fail_raises_error(self, lib_mock):
         lib_mock.sp_session_flush_caches.return_value = (
@@ -378,9 +356,7 @@ class SessionTest(unittest.TestCase):
             session.flush_caches()
 
     def test_preferred_bitrate(self, lib_mock):
-        lib_mock.sp_session_preferred_bitrate.return_value = (
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_session_preferred_bitrate.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(lib_mock)
 
         session.preferred_bitrate(spotify.Bitrate.BITRATE_320k)
@@ -445,9 +421,7 @@ class SessionTest(unittest.TestCase):
         self.assertFalse(result)
 
     def test_set_volume_normalization(self, lib_mock):
-        lib_mock.sp_session_set_volume_normalization.return_value = (
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_session_set_volume_normalization.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(lib_mock)
 
         session.volume_normalization = True
@@ -510,8 +484,8 @@ class SessionTest(unittest.TestCase):
 
     @mock.patch('spotify.playlist.lib', spec=spotify.lib)
     def test_get_starred(self, playlist_lib_mock, lib_mock):
-        lib_mock.sp_session_starred_for_user_create.return_value = (
-            spotify.ffi.cast('sp_playlist *', 42)
+        lib_mock.sp_session_starred_for_user_create.return_value = spotify.ffi.cast(
+            'sp_playlist *', 42
         )
         session = tests.create_real_session(lib_mock)
 
@@ -542,9 +516,7 @@ class SessionTest(unittest.TestCase):
         ):
             result = session.get_starred()
 
-        lib_mock.sp_session_starred_create.assert_called_with(
-            session._sp_session
-        )
+        lib_mock.sp_session_starred_create.assert_called_with(session._sp_session)
         self.assertIsInstance(result, spotify.Playlist)
 
         # Since we *created* the sp_playlist, we already have a refcount of 1
@@ -553,9 +525,7 @@ class SessionTest(unittest.TestCase):
         self.assertEqual(playlist_lib_mock.sp_playlist_add_ref.call_count, 0)
 
     def test_get_starred_if_not_logged_in(self, lib_mock):
-        lib_mock.sp_session_starred_for_user_create.return_value = (
-            spotify.ffi.NULL
-        )
+        lib_mock.sp_session_starred_for_user_create.return_value = spotify.ffi.NULL
         session = tests.create_real_session(lib_mock)
 
         with pytest.warns(
@@ -585,9 +555,7 @@ class SessionTest(unittest.TestCase):
         # Since we *created* the sp_playlistcontainer, we already have a
         # refcount of 1 and shouldn't increase the refcount when wrapping this
         # sp_playlistcontainer in a PlaylistContainer object
-        self.assertEqual(
-            playlist_lib_mock.sp_playlistcontainer_add_ref.call_count, 0
-        )
+        self.assertEqual(playlist_lib_mock.sp_playlistcontainer_add_ref.call_count, 0)
 
     @mock.patch('spotify.playlist_container.lib', spec=spotify.lib)
     def test_get_published_playlists_for_current_user(
@@ -774,9 +742,7 @@ class SessionTest(unittest.TestCase):
         session = tests.create_real_session(lib_mock)
         toplist_mock.return_value = mock.sentinel.toplist
 
-        result = session.get_toplist(
-            type=spotify.ToplistType.TRACKS, region='NO'
-        )
+        result = session.get_toplist(type=spotify.ToplistType.TRACKS, region='NO')
 
         self.assertIs(result, mock.sentinel.toplist)
         toplist_mock.assert_called_with(
@@ -802,9 +768,7 @@ class SessionCallbacksTest(unittest.TestCase):
             session._sp_session, int(spotify.ErrorType.BAD_API_VERSION)
         )
 
-        callback.assert_called_once_with(
-            session, spotify.ErrorType.BAD_API_VERSION
-        )
+        callback.assert_called_once_with(session, spotify.ErrorType.BAD_API_VERSION)
 
     def test_logged_out_callback(self, lib_mock):
         callback = mock.Mock()
@@ -874,12 +838,8 @@ class SessionCallbacksTest(unittest.TestCase):
             session._sp_session, sp_audioformat, frames_void_ptr, num_frames
         )
 
-        callback.assert_called_once_with(
-            session, mock.ANY, mock.ANY, num_frames
-        )
-        self.assertEqual(
-            callback.call_args[0][1]._sp_audioformat, sp_audioformat
-        )
+        callback.assert_called_once_with(session, mock.ANY, mock.ANY, num_frames)
+        self.assertEqual(callback.call_args[0][1]._sp_audioformat, sp_audioformat)
         self.assertEqual(callback.call_args[0][2][:5], b'abc\x00\x00')
         self.assertEqual(result, num_frames)
 
@@ -934,9 +894,7 @@ class SessionCallbacksTest(unittest.TestCase):
             session._sp_session, int(spotify.ErrorType.NO_STREAM_AVAILABLE)
         )
 
-        callback.assert_called_once_with(
-            session, spotify.ErrorType.NO_STREAM_AVAILABLE
-        )
+        callback.assert_called_once_with(session, spotify.ErrorType.NO_STREAM_AVAILABLE)
 
     def test_user_info_updated_callback(self, lib_mock):
         callback = mock.Mock()
@@ -1017,9 +975,7 @@ class SessionCallbacksTest(unittest.TestCase):
             session._sp_session, int(spotify.ErrorType.LASTFM_AUTH_ERROR)
         )
 
-        callback.assert_called_once_with(
-            session, spotify.ErrorType.LASTFM_AUTH_ERROR
-        )
+        callback.assert_called_once_with(session, spotify.ErrorType.LASTFM_AUTH_ERROR)
 
     def test_private_session_mode_changed_callback(self, lib_mock):
         callback = mock.Mock()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -12,7 +12,7 @@ from spotify.session import _SessionCallbacks
 from tests import mock
 
 
-@mock.patch('spotify.session.lib', spec=spotify.lib)
+@mock.patch("spotify.session.lib", spec=spotify.lib)
 class SessionTest(unittest.TestCase):
     def tearDown(self):
         spotify._session_instance = None
@@ -23,7 +23,7 @@ class SessionTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             tests.create_real_session(lib_mock)
 
-    @mock.patch('spotify.Config')
+    @mock.patch("spotify.Config")
     def test_creates_config_if_none_provided(self, config_cls_mock, lib_mock):
         lib_mock.sp_session_create.return_value = spotify.ErrorType.OK
 
@@ -32,7 +32,7 @@ class SessionTest(unittest.TestCase):
         config_cls_mock.assert_called_once_with()
         self.assertEqual(session.config, config_cls_mock.return_value)
 
-    @mock.patch('spotify.Config')
+    @mock.patch("spotify.Config")
     def test_tries_to_load_application_key_if_none_provided(
         self, config_cls_mock, lib_mock
     ):
@@ -47,7 +47,7 @@ class SessionTest(unittest.TestCase):
     def test_raises_error_if_not_ok(self, lib_mock):
         lib_mock.sp_session_create.return_value = spotify.ErrorType.BAD_API_VERSION
         config = spotify.Config()
-        config.application_key = b'\x01' * 321
+        config.application_key = b"\x01" * 321
 
         with self.assertRaises(spotify.Error):
             spotify.Session(config=config)
@@ -61,7 +61,7 @@ class SessionTest(unittest.TestCase):
 
         lib_mock.sp_session_create.side_effect = func
         config = spotify.Config()
-        config.application_key = b'\x01' * 321
+        config.application_key = b"\x01" * 321
 
         session = spotify.Session(config=config)
         session = None  # noqa
@@ -75,49 +75,49 @@ class SessionTest(unittest.TestCase):
         session = tests.create_real_session(lib_mock)
 
         with self.assertRaises(AttributeError):
-            session.login('alice')
+            session.login("alice")
 
     def test_login_with_password(self, lib_mock):
         lib_mock.sp_session_login.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(lib_mock)
 
-        session.login('alice', 'secret')
+        session.login("alice", "secret")
 
         lib_mock.sp_session_login.assert_called_once_with(
             session._sp_session, mock.ANY, mock.ANY, False, spotify.ffi.NULL
         )
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_session_login.call_args[0][1]),
-            b'alice',
+            b"alice",
         )
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_session_login.call_args[0][2]),
-            b'secret',
+            b"secret",
         )
 
     def test_login_with_blob(self, lib_mock):
         lib_mock.sp_session_login.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(lib_mock)
 
-        session.login('alice', blob='secret blob')
+        session.login("alice", blob="secret blob")
 
         lib_mock.sp_session_login.assert_called_once_with(
             session._sp_session, mock.ANY, spotify.ffi.NULL, False, mock.ANY
         )
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_session_login.call_args[0][1]),
-            b'alice',
+            b"alice",
         )
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_session_login.call_args[0][4]),
-            b'secret blob',
+            b"secret blob",
         )
 
     def test_login_with_remember_me_flag(self, lib_mock):
         lib_mock.sp_session_login.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(lib_mock)
 
-        session.login('alice', 'secret', remember_me='anything truish')
+        session.login("alice", "secret", remember_me="anything truish")
 
         lib_mock.sp_session_login.assert_called_once_with(
             session._sp_session, mock.ANY, mock.ANY, True, spotify.ffi.NULL
@@ -128,7 +128,7 @@ class SessionTest(unittest.TestCase):
         session = tests.create_real_session(lib_mock)
 
         with self.assertRaises(spotify.Error):
-            session.login('alice', 'secret')
+            session.login("alice", "secret")
 
     def test_logout(self, lib_mock):
         lib_mock.sp_session_logout.return_value = spotify.ErrorType.OK
@@ -146,7 +146,7 @@ class SessionTest(unittest.TestCase):
             session.logout()
 
     def test_remembered_user_name_grows_buffer_to_fit_username(self, lib_mock):
-        username = 'alice' * 100
+        username = "alice" * 100
 
         lib_mock.sp_session_remembered_user.side_effect = tests.buffer_writer(username)
         session = tests.create_real_session(lib_mock)
@@ -199,9 +199,9 @@ class SessionTest(unittest.TestCase):
         with self.assertRaises(spotify.Error):
             session.forget_me()
 
-    @mock.patch('spotify.user.lib', spec=spotify.lib)
+    @mock.patch("spotify.user.lib", spec=spotify.lib)
     def test_user(self, user_lib_mock, lib_mock):
-        lib_mock.sp_session_user.return_value = spotify.ffi.cast('sp_user *', 42)
+        lib_mock.sp_session_user.return_value = spotify.ffi.cast("sp_user *", 42)
         session = tests.create_real_session(lib_mock)
 
         result = session.user
@@ -219,54 +219,54 @@ class SessionTest(unittest.TestCase):
         self.assertIsNone(result)
 
     def test_user_name(self, lib_mock):
-        lib_mock.sp_session_user_name.return_value = spotify.ffi.new('char[]', b'alice')
+        lib_mock.sp_session_user_name.return_value = spotify.ffi.new("char[]", b"alice")
         session = tests.create_real_session(lib_mock)
 
         result = session.user_name
 
         lib_mock.sp_session_user_name.assert_called_with(session._sp_session)
-        self.assertEqual(result, 'alice')
+        self.assertEqual(result, "alice")
 
     def test_user_country(self, lib_mock):
-        lib_mock.sp_session_user_country.return_value = ord('S') << 8 | ord('E')
+        lib_mock.sp_session_user_country.return_value = ord("S") << 8 | ord("E")
         session = tests.create_real_session(lib_mock)
 
         result = session.user_country
 
         lib_mock.sp_session_user_country.assert_called_with(session._sp_session)
-        self.assertEqual(result, 'SE')
+        self.assertEqual(result, "SE")
 
-    @mock.patch('spotify.playlist_container.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist_container.lib", spec=spotify.lib)
     def test_playlist_container(self, playlist_lib_mock, lib_mock):
         lib_mock.sp_session_playlistcontainer.return_value = spotify.ffi.cast(
-            'sp_playlistcontainer *', 42
+            "sp_playlistcontainer *", 42
         )
         session = tests.create_real_session(lib_mock)
 
         with pytest.warns(
-            UserWarning, match='Spotify broke the libspotify playlists API'
+            UserWarning, match="Spotify broke the libspotify playlists API"
         ):
             result = session.playlist_container
 
         lib_mock.sp_session_playlistcontainer.assert_called_with(session._sp_session)
         self.assertIsInstance(result, spotify.PlaylistContainer)
 
-    @mock.patch('spotify.playlist_container.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist_container.lib", spec=spotify.lib)
     def test_playlist_container_if_already_listened_to(
         self, playlist_lib_mock, lib_mock
     ):
         lib_mock.sp_session_playlistcontainer.return_value = spotify.ffi.cast(
-            'sp_playlistcontainer *', 42
+            "sp_playlistcontainer *", 42
         )
         session = tests.create_real_session(lib_mock)
 
         with pytest.warns(
-            UserWarning, match='Spotify broke the libspotify playlists API'
+            UserWarning, match="Spotify broke the libspotify playlists API"
         ):
             result1 = session.playlist_container
         result1.on(spotify.PlaylistContainerEvent.PLAYLIST_ADDED, lambda *args: None)
         with pytest.warns(
-            UserWarning, match='Spotify broke the libspotify playlists API'
+            UserWarning, match="Spotify broke the libspotify playlists API"
         ):
             result2 = session.playlist_container
 
@@ -280,22 +280,22 @@ class SessionTest(unittest.TestCase):
         session = tests.create_real_session(lib_mock)
 
         with pytest.warns(
-            UserWarning, match='Spotify broke the libspotify playlists API'
+            UserWarning, match="Spotify broke the libspotify playlists API"
         ):
             result = session.playlist_container
 
         lib_mock.sp_session_playlistcontainer.assert_called_with(session._sp_session)
         self.assertIsNone(result)
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_inbox(self, playlist_lib_mock, lib_mock):
         lib_mock.sp_session_inbox_create.return_value = spotify.ffi.cast(
-            'sp_playlist *', 42
+            "sp_playlist *", 42
         )
         session = tests.create_real_session(lib_mock)
 
         with pytest.warns(
-            UserWarning, match='Spotify broke the libspotify playlists API'
+            UserWarning, match="Spotify broke the libspotify playlists API"
         ):
             result = session.inbox
 
@@ -312,7 +312,7 @@ class SessionTest(unittest.TestCase):
         session = tests.create_real_session(lib_mock)
 
         with pytest.warns(
-            UserWarning, match='Spotify broke the libspotify playlists API'
+            UserWarning, match="Spotify broke the libspotify playlists API"
         ):
             result = session.inbox
 
@@ -461,7 +461,7 @@ class SessionTest(unittest.TestCase):
         with self.assertRaises(spotify.Error):
             session.process_events()
 
-    @mock.patch('spotify.InboxPostResult', spec=spotify.InboxPostResult)
+    @mock.patch("spotify.InboxPostResult", spec=spotify.InboxPostResult)
     def test_inbox_post_tracks(self, inbox_mock, lib_mock):
         session = tests.create_real_session(lib_mock)
         inbox_instance_mock = inbox_mock.return_value
@@ -482,20 +482,20 @@ class SessionTest(unittest.TestCase):
         )
         self.assertEqual(result, inbox_instance_mock)
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_get_starred(self, playlist_lib_mock, lib_mock):
         lib_mock.sp_session_starred_for_user_create.return_value = spotify.ffi.cast(
-            'sp_playlist *', 42
+            "sp_playlist *", 42
         )
         session = tests.create_real_session(lib_mock)
 
         with pytest.warns(
-            UserWarning, match='Spotify broke the libspotify playlists API'
+            UserWarning, match="Spotify broke the libspotify playlists API"
         ):
-            result = session.get_starred('alice')
+            result = session.get_starred("alice")
 
         lib_mock.sp_session_starred_for_user_create.assert_called_with(
-            session._sp_session, b'alice'
+            session._sp_session, b"alice"
         )
         self.assertIsInstance(result, spotify.Playlist)
 
@@ -504,15 +504,15 @@ class SessionTest(unittest.TestCase):
         # a Playlist object
         self.assertEqual(playlist_lib_mock.sp_playlist_add_ref.call_count, 0)
 
-    @mock.patch('spotify.playlist.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist.lib", spec=spotify.lib)
     def test_get_starred_for_current_user(self, playlist_lib_mock, lib_mock):
         lib_mock.sp_session_starred_create.return_value = spotify.ffi.cast(
-            'sp_playlist *', 42
+            "sp_playlist *", 42
         )
         session = tests.create_real_session(lib_mock)
 
         with pytest.warns(
-            UserWarning, match='Spotify broke the libspotify playlists API'
+            UserWarning, match="Spotify broke the libspotify playlists API"
         ):
             result = session.get_starred()
 
@@ -529,27 +529,27 @@ class SessionTest(unittest.TestCase):
         session = tests.create_real_session(lib_mock)
 
         with pytest.warns(
-            UserWarning, match='Spotify broke the libspotify playlists API'
+            UserWarning, match="Spotify broke the libspotify playlists API"
         ):
-            result = session.get_starred('alice')
+            result = session.get_starred("alice")
 
         lib_mock.sp_session_starred_for_user_create.assert_called_with(
-            session._sp_session, b'alice'
+            session._sp_session, b"alice"
         )
         self.assertIsNone(result)
 
-    @mock.patch('spotify.playlist_container.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist_container.lib", spec=spotify.lib)
     def test_get_published_playlists(self, playlist_lib_mock, lib_mock):
         func_mock = lib_mock.sp_session_publishedcontainer_for_user_create
-        func_mock.return_value = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        func_mock.return_value = spotify.ffi.cast("sp_playlistcontainer *", 42)
         session = tests.create_real_session(lib_mock)
 
         with pytest.warns(
-            UserWarning, match='Spotify broke the libspotify playlists API'
+            UserWarning, match="Spotify broke the libspotify playlists API"
         ):
-            result = session.get_published_playlists('alice')
+            result = session.get_published_playlists("alice")
 
-        func_mock.assert_called_with(session._sp_session, b'alice')
+        func_mock.assert_called_with(session._sp_session, b"alice")
         self.assertIsInstance(result, spotify.PlaylistContainer)
 
         # Since we *created* the sp_playlistcontainer, we already have a
@@ -557,16 +557,16 @@ class SessionTest(unittest.TestCase):
         # sp_playlistcontainer in a PlaylistContainer object
         self.assertEqual(playlist_lib_mock.sp_playlistcontainer_add_ref.call_count, 0)
 
-    @mock.patch('spotify.playlist_container.lib', spec=spotify.lib)
+    @mock.patch("spotify.playlist_container.lib", spec=spotify.lib)
     def test_get_published_playlists_for_current_user(
         self, playlist_lib_mock, lib_mock
     ):
         func_mock = lib_mock.sp_session_publishedcontainer_for_user_create
-        func_mock.return_value = spotify.ffi.cast('sp_playlistcontainer *', 42)
+        func_mock.return_value = spotify.ffi.cast("sp_playlistcontainer *", 42)
         session = tests.create_real_session(lib_mock)
 
         with pytest.warns(
-            UserWarning, match='Spotify broke the libspotify playlists API'
+            UserWarning, match="Spotify broke the libspotify playlists API"
         ):
             result = session.get_published_playlists()
 
@@ -579,42 +579,42 @@ class SessionTest(unittest.TestCase):
         session = tests.create_real_session(lib_mock)
 
         with pytest.warns(
-            UserWarning, match='Spotify broke the libspotify playlists API'
+            UserWarning, match="Spotify broke the libspotify playlists API"
         ):
-            result = session.get_published_playlists('alice')
+            result = session.get_published_playlists("alice")
 
-        func_mock.assert_called_with(session._sp_session, b'alice')
+        func_mock.assert_called_with(session._sp_session, b"alice")
         self.assertIsNone(result)
 
-    @mock.patch('spotify.Link')
+    @mock.patch("spotify.Link")
     def test_get_link(self, link_mock, lib_mock):
         session = tests.create_real_session(lib_mock)
         link_mock.return_value = mock.sentinel.link
 
-        result = session.get_link('spotify:any:foo')
+        result = session.get_link("spotify:any:foo")
 
         self.assertIs(result, mock.sentinel.link)
-        link_mock.assert_called_with(session, uri='spotify:any:foo')
+        link_mock.assert_called_with(session, uri="spotify:any:foo")
 
-    @mock.patch('spotify.Track')
+    @mock.patch("spotify.Track")
     def test_get_track(self, track_mock, lib_mock):
         session = tests.create_real_session(lib_mock)
         track_mock.return_value = mock.sentinel.track
 
-        result = session.get_track('spotify:track:foo')
+        result = session.get_track("spotify:track:foo")
 
         self.assertIs(result, mock.sentinel.track)
-        track_mock.assert_called_with(session, uri='spotify:track:foo')
+        track_mock.assert_called_with(session, uri="spotify:track:foo")
 
-    @mock.patch('spotify.Track')
+    @mock.patch("spotify.Track")
     def test_get_local_track(self, track_mock, lib_mock):
         session = tests.create_real_session(lib_mock)
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         lib_mock.sp_localtrack_create.return_value = sp_track
         track_mock.return_value = mock.sentinel.track
 
         track = session.get_local_track(
-            artist='foo', title='bar', album='baz', length=210000
+            artist="foo", title="bar", album="baz", length=210000
         )
 
         self.assertEqual(track, mock.sentinel.track)
@@ -623,15 +623,15 @@ class SessionTest(unittest.TestCase):
         )
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_localtrack_create.call_args[0][0]),
-            b'foo',
+            b"foo",
         )
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_localtrack_create.call_args[0][1]),
-            b'bar',
+            b"bar",
         )
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_localtrack_create.call_args[0][2]),
-            b'baz',
+            b"baz",
         )
         self.assertEqual(lib_mock.sp_localtrack_create.call_args[0][3], 210000)
 
@@ -640,10 +640,10 @@ class SessionTest(unittest.TestCase):
         # Track object
         track_mock.assert_called_with(session, sp_track=sp_track, add_ref=False)
 
-    @mock.patch('spotify.Track')
+    @mock.patch("spotify.Track")
     def test_get_local_track_with_defaults(self, track_mock, lib_mock):
         session = tests.create_real_session(lib_mock)
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         lib_mock.sp_localtrack_create.return_value = sp_track
         track_mock.return_value = mock.sentinel.track
 
@@ -655,15 +655,15 @@ class SessionTest(unittest.TestCase):
         )
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_localtrack_create.call_args[0][0]),
-            b'',
+            b"",
         )
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_localtrack_create.call_args[0][1]),
-            b'',
+            b"",
         )
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_localtrack_create.call_args[0][2]),
-            b'',
+            b"",
         )
         self.assertEqual(lib_mock.sp_localtrack_create.call_args[0][3], -1)
 
@@ -672,89 +672,89 @@ class SessionTest(unittest.TestCase):
         # Track object
         track_mock.assert_called_with(session, sp_track=sp_track, add_ref=False)
 
-    @mock.patch('spotify.Album')
+    @mock.patch("spotify.Album")
     def test_get_album(self, album_mock, lib_mock):
         session = tests.create_real_session(lib_mock)
         album_mock.return_value = mock.sentinel.album
 
-        result = session.get_album('spotify:album:foo')
+        result = session.get_album("spotify:album:foo")
 
         self.assertIs(result, mock.sentinel.album)
-        album_mock.assert_called_with(session, uri='spotify:album:foo')
+        album_mock.assert_called_with(session, uri="spotify:album:foo")
 
-    @mock.patch('spotify.Artist')
+    @mock.patch("spotify.Artist")
     def test_get_artist(self, artist_mock, lib_mock):
         session = tests.create_real_session(lib_mock)
         artist_mock.return_value = mock.sentinel.artist
 
-        result = session.get_artist('spotify:artist:foo')
+        result = session.get_artist("spotify:artist:foo")
 
         self.assertIs(result, mock.sentinel.artist)
-        artist_mock.assert_called_with(session, uri='spotify:artist:foo')
+        artist_mock.assert_called_with(session, uri="spotify:artist:foo")
 
-    @mock.patch('spotify.Playlist')
+    @mock.patch("spotify.Playlist")
     def test_get_playlist(self, playlist_mock, lib_mock):
         session = tests.create_real_session(lib_mock)
         playlist_mock.return_value = mock.sentinel.playlist
 
         with pytest.warns(
-            UserWarning, match='Spotify broke the libspotify playlists API'
+            UserWarning, match="Spotify broke the libspotify playlists API"
         ):
-            result = session.get_playlist('spotify:playlist:foo')
+            result = session.get_playlist("spotify:playlist:foo")
 
         self.assertIs(result, mock.sentinel.playlist)
-        playlist_mock.assert_called_with(session, uri='spotify:playlist:foo')
+        playlist_mock.assert_called_with(session, uri="spotify:playlist:foo")
 
-    @mock.patch('spotify.User')
+    @mock.patch("spotify.User")
     def test_get_user(self, user_mock, lib_mock):
         session = tests.create_real_session(lib_mock)
         user_mock.return_value = mock.sentinel.user
 
-        result = session.get_user('spotify:user:foo')
+        result = session.get_user("spotify:user:foo")
 
         self.assertIs(result, mock.sentinel.user)
-        user_mock.assert_called_with(session, uri='spotify:user:foo')
+        user_mock.assert_called_with(session, uri="spotify:user:foo")
 
-    @mock.patch('spotify.Image')
+    @mock.patch("spotify.Image")
     def test_get_image(self, image_mock, lib_mock):
         session = tests.create_real_session(lib_mock)
         callback = mock.Mock()
         image_mock.return_value = mock.sentinel.image
 
-        result = session.get_image('spotify:image:foo', callback=callback)
+        result = session.get_image("spotify:image:foo", callback=callback)
 
         self.assertIs(result, mock.sentinel.image)
         image_mock.assert_called_with(
-            session, uri='spotify:image:foo', callback=callback
+            session, uri="spotify:image:foo", callback=callback
         )
 
-    @mock.patch('spotify.Search')
+    @mock.patch("spotify.Search")
     def test_search(self, search_mock, lib_mock):
         session = tests.create_real_session(lib_mock)
 
         with self.assertRaises(Exception):
-            session.search('alice')
+            session.search("alice")
 
         self.assertEqual(search_mock.call_count, 0)
 
-    @mock.patch('spotify.Toplist')
+    @mock.patch("spotify.Toplist")
     def test_toplist(self, toplist_mock, lib_mock):
         session = tests.create_real_session(lib_mock)
         toplist_mock.return_value = mock.sentinel.toplist
 
-        result = session.get_toplist(type=spotify.ToplistType.TRACKS, region='NO')
+        result = session.get_toplist(type=spotify.ToplistType.TRACKS, region="NO")
 
         self.assertIs(result, mock.sentinel.toplist)
         toplist_mock.assert_called_with(
             session,
             type=spotify.ToplistType.TRACKS,
-            region='NO',
+            region="NO",
             canonical_username=None,
             callback=None,
         )
 
 
-@mock.patch('spotify.session.lib', spec=spotify.lib)
+@mock.patch("spotify.session.lib", spec=spotify.lib)
 class SessionCallbacksTest(unittest.TestCase):
     def tearDown(self):
         spotify._session_instance = None
@@ -803,11 +803,11 @@ class SessionCallbacksTest(unittest.TestCase):
         callback = mock.Mock()
         session = tests.create_real_session(lib_mock)
         session.on(spotify.SessionEvent.MESSAGE_TO_USER, callback)
-        data = spotify.ffi.new('char[]', b'a log message\n')
+        data = spotify.ffi.new("char[]", b"a log message\n")
 
         _SessionCallbacks.message_to_user(session._sp_session, data)
 
-        callback.assert_called_once_with(session, 'a log message')
+        callback.assert_called_once_with(session, "a log message")
 
     def test_notify_main_thread_callback(self, lib_mock):
         callback = mock.Mock()
@@ -819,20 +819,20 @@ class SessionCallbacksTest(unittest.TestCase):
         callback.assert_called_once_with(session)
 
     def test_music_delivery_callback(self, lib_mock):
-        sp_audioformat = spotify.ffi.new('sp_audioformat *')
+        sp_audioformat = spotify.ffi.new("sp_audioformat *")
         sp_audioformat.channels = 2
         audio_format = spotify.AudioFormat(sp_audioformat)
 
         num_frames = 10
         frames_size = audio_format.frame_size() * num_frames
-        frames = spotify.ffi.new('char[]', frames_size)
-        frames[0:3] = [b'a', b'b', b'c']
-        frames_void_ptr = spotify.ffi.cast('void *', frames)
+        frames = spotify.ffi.new("char[]", frames_size)
+        frames[0:3] = [b"a", b"b", b"c"]
+        frames_void_ptr = spotify.ffi.cast("void *", frames)
 
         callback = mock.Mock()
         callback.return_value = num_frames
         session = tests.create_real_session(lib_mock)
-        session.on('music_delivery', callback)
+        session.on("music_delivery", callback)
 
         result = _SessionCallbacks.music_delivery(
             session._sp_session, sp_audioformat, frames_void_ptr, num_frames
@@ -840,16 +840,16 @@ class SessionCallbacksTest(unittest.TestCase):
 
         callback.assert_called_once_with(session, mock.ANY, mock.ANY, num_frames)
         self.assertEqual(callback.call_args[0][1]._sp_audioformat, sp_audioformat)
-        self.assertEqual(callback.call_args[0][2][:5], b'abc\x00\x00')
+        self.assertEqual(callback.call_args[0][2][:5], b"abc\x00\x00")
         self.assertEqual(result, num_frames)
 
     def test_music_delivery_without_callback_does_not_consume(self, lib_mock):
         session = tests.create_real_session(lib_mock)
 
-        sp_audioformat = spotify.ffi.new('sp_audioformat *')
+        sp_audioformat = spotify.ffi.new("sp_audioformat *")
         num_frames = 10
-        frames = spotify.ffi.new('char[]', 0)
-        frames_void_ptr = spotify.ffi.cast('void *', frames)
+        frames = spotify.ffi.new("char[]", 0)
+        frames_void_ptr = spotify.ffi.cast("void *", frames)
 
         result = _SessionCallbacks.music_delivery(
             session._sp_session, sp_audioformat, frames_void_ptr, num_frames
@@ -870,11 +870,11 @@ class SessionCallbacksTest(unittest.TestCase):
         callback = mock.Mock()
         session = tests.create_real_session(lib_mock)
         session.on(spotify.SessionEvent.LOG_MESSAGE, callback)
-        data = spotify.ffi.new('char[]', b'a log message\n')
+        data = spotify.ffi.new("char[]", b"a log message\n")
 
         _SessionCallbacks.log_message(session._sp_session, data)
 
-        callback.assert_called_once_with(session, 'a log message')
+        callback.assert_called_once_with(session, "a log message")
 
     def test_end_of_track_callback(self, lib_mock):
         callback = mock.Mock()
@@ -928,7 +928,7 @@ class SessionCallbacksTest(unittest.TestCase):
         callback.return_value = spotify.AudioBufferStats(100, 5)
         session = tests.create_real_session(lib_mock)
         session.on(spotify.SessionEvent.GET_AUDIO_BUFFER_STATS, callback)
-        sp_audio_buffer_stats = spotify.ffi.new('sp_audio_buffer_stats *')
+        sp_audio_buffer_stats = spotify.ffi.new("sp_audio_buffer_stats *")
 
         _SessionCallbacks.get_audio_buffer_stats(
             session._sp_session, sp_audio_buffer_stats
@@ -951,11 +951,11 @@ class SessionCallbacksTest(unittest.TestCase):
         callback = mock.Mock()
         session = tests.create_real_session(lib_mock)
         session.on(spotify.SessionEvent.CREDENTIALS_BLOB_UPDATED, callback)
-        data = spotify.ffi.new('char[]', b'a credentials blob')
+        data = spotify.ffi.new("char[]", b"a credentials blob")
 
         _SessionCallbacks.credentials_blob_updated(session._sp_session, data)
 
-        callback.assert_called_once_with(session, b'a credentials blob')
+        callback.assert_called_once_with(session, b"a credentials blob")
 
     def test_connection_state_updated_callback(self, lib_mock):
         callback = mock.Mock()

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -36,7 +36,7 @@ class AlsaSinkTest(unittest.TestCase, BaseSinkTest):
         self.session.num_listeners.return_value = 0
         self.alsaaudio = mock.Mock()
         self.alsaaudio.pcms = mock.Mock()
-        with mock.patch.dict('sys.modules', {'alsaaudio': self.alsaaudio}):
+        with mock.patch.dict("sys.modules", {"alsaaudio": self.alsaaudio}):
             self.sink = spotify.AlsaSink(self.session)
 
     def test_off_closes_audio_device(self):
@@ -65,7 +65,7 @@ class AlsaSinkTest(unittest.TestCase, BaseSinkTest):
 
         # The ``device`` kwarg was added in pyalsaaudio 0.8
         self.alsaaudio.PCM.assert_called_with(
-            mode=self.alsaaudio.PCM_NONBLOCK, device='default'
+            mode=self.alsaaudio.PCM_NONBLOCK, device="default"
         )
 
         device.setformat.assert_called_with(mock.ANY)
@@ -91,7 +91,7 @@ class AlsaSinkTest(unittest.TestCase, BaseSinkTest):
 
         # The ``card`` kwarg was deprecated in pyalsaaudio 0.8
         self.alsaaudio.PCM.assert_called_with(
-            mode=self.alsaaudio.PCM_NONBLOCK, card='default'
+            mode=self.alsaaudio.PCM_NONBLOCK, card="default"
         )
 
     def test_sets_little_endian_format_if_little_endian_system(self):
@@ -102,8 +102,8 @@ class AlsaSinkTest(unittest.TestCase, BaseSinkTest):
         audio_format.sample_type = spotify.SampleType.INT16_NATIVE_ENDIAN
         num_frames = 2048
 
-        with mock.patch('spotify.sink.sys') as sys_mock:
-            sys_mock.byteorder = 'little'
+        with mock.patch("spotify.sink.sys") as sys_mock:
+            sys_mock.byteorder = "little"
 
             self.sink._on_music_delivery(
                 mock.sentinel.session,
@@ -122,8 +122,8 @@ class AlsaSinkTest(unittest.TestCase, BaseSinkTest):
         audio_format.sample_type = spotify.SampleType.INT16_NATIVE_ENDIAN
         num_frames = 2048
 
-        with mock.patch('spotify.sink.sys') as sys_mock:
-            sys_mock.byteorder = 'big'
+        with mock.patch("spotify.sink.sys") as sys_mock:
+            sys_mock.byteorder = "big"
 
             self.sink._on_music_delivery(
                 mock.sentinel.session,
@@ -155,7 +155,7 @@ class PortAudioSinkTest(unittest.TestCase, BaseSinkTest):
         self.session = mock.Mock()
         self.session.num_listeners.return_value = 0
         self.pyaudio = mock.Mock()
-        with mock.patch.dict('sys.modules', {'pyaudio': self.pyaudio}):
+        with mock.patch.dict("sys.modules", {"pyaudio": self.pyaudio}):
             self.sink = spotify.PortAudioSink(self.session)
 
     def test_init_creates_device(self):

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-
 from tests import mock
 
 

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -147,9 +147,7 @@ class AlsaSinkTest(unittest.TestCase, BaseSinkTest):
         )
 
         self.sink._device.write.assert_called_with(mock.sentinel.frames)
-        self.assertEqual(
-            num_consumed_frames, self.sink._device.write.return_value
-        )
+        self.assertEqual(num_consumed_frames, self.sink._device.write.return_value)
 
 
 class PortAudioSinkTest(unittest.TestCase, BaseSinkTest):

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -19,18 +19,12 @@ class SocialTest(unittest.TestCase):
 
         result = session.social.private_session
 
-        lib_mock.sp_session_is_private_session.assert_called_with(
-            session._sp_session
-        )
+        lib_mock.sp_session_is_private_session.assert_called_with(session._sp_session)
         self.assertFalse(result)
 
     @mock.patch('spotify.connection.lib', spec=spotify.lib)
-    def test_set_private_session(
-        self, conn_lib_mock, session_lib_mock, lib_mock
-    ):
-        lib_mock.sp_session_set_private_session.return_value = (
-            spotify.ErrorType.OK
-        )
+    def test_set_private_session(self, conn_lib_mock, session_lib_mock, lib_mock):
+        lib_mock.sp_session_set_private_session.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(session_lib_mock)
 
         session.social.private_session = True
@@ -53,9 +47,7 @@ class SocialTest(unittest.TestCase):
 
     def test_is_scrobbling(self, session_lib_mock, lib_mock):
         def func(sp_session_ptr, sp_social_provider, sp_scrobbling_state_ptr):
-            sp_scrobbling_state_ptr[
-                0
-            ] = spotify.ScrobblingState.USE_GLOBAL_SETTING
+            sp_scrobbling_state_ptr[0] = spotify.ScrobblingState.USE_GLOBAL_SETTING
             return spotify.ErrorType.OK
 
         lib_mock.sp_session_is_scrobbling.side_effect = func
@@ -112,32 +104,24 @@ class SocialTest(unittest.TestCase):
         lib_mock.sp_session_is_scrobbling_possible.side_effect = func
         session = tests.create_real_session(session_lib_mock)
 
-        result = session.social.is_scrobbling_possible(
-            spotify.SocialProvider.FACEBOOK
-        )
+        result = session.social.is_scrobbling_possible(spotify.SocialProvider.FACEBOOK)
 
         lib_mock.sp_session_is_scrobbling_possible.assert_called_with(
             session._sp_session, spotify.SocialProvider.FACEBOOK, mock.ANY
         )
         self.assertTrue(result)
 
-    def test_is_scrobbling_possible_fail_raises_error(
-        self, session_lib_mock, lib_mock
-    ):
+    def test_is_scrobbling_possible_fail_raises_error(self, session_lib_mock, lib_mock):
         lib_mock.sp_session_is_scrobbling_possible.return_value = (
             spotify.ErrorType.BAD_API_VERSION
         )
         session = tests.create_real_session(session_lib_mock)
 
         with self.assertRaises(spotify.Error):
-            session.social.is_scrobbling_possible(
-                spotify.SocialProvider.FACEBOOK
-            )
+            session.social.is_scrobbling_possible(spotify.SocialProvider.FACEBOOK)
 
     def test_set_social_credentials(self, session_lib_mock, lib_mock):
-        lib_mock.sp_session_set_social_credentials.return_value = (
-            spotify.ErrorType.OK
-        )
+        lib_mock.sp_session_set_social_credentials.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(session_lib_mock)
 
         session.social.set_social_credentials(
@@ -163,12 +147,8 @@ class SocialTest(unittest.TestCase):
             b'secret',
         )
 
-    def test_set_social_credentials_fail_raises_error(
-        self, session_lib_mock, lib_mock
-    ):
-        lib_mock.sp_session_login.return_value = (
-            spotify.ErrorType.BAD_API_VERSION
-        )
+    def test_set_social_credentials_fail_raises_error(self, session_lib_mock, lib_mock):
+        lib_mock.sp_session_login.return_value = spotify.ErrorType.BAD_API_VERSION
         session = tests.create_real_session(session_lib_mock)
 
         with self.assertRaises(spotify.Error):

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-
 import tests
 from tests import mock
 

--- a/tests/test_social.py
+++ b/tests/test_social.py
@@ -7,8 +7,8 @@ import tests
 from tests import mock
 
 
-@mock.patch('spotify.social.lib', spec=spotify.lib)
-@mock.patch('spotify.session.lib', spec=spotify.lib)
+@mock.patch("spotify.social.lib", spec=spotify.lib)
+@mock.patch("spotify.session.lib", spec=spotify.lib)
 class SocialTest(unittest.TestCase):
     def tearDown(self):
         spotify._session_instance = None
@@ -22,7 +22,7 @@ class SocialTest(unittest.TestCase):
         lib_mock.sp_session_is_private_session.assert_called_with(session._sp_session)
         self.assertFalse(result)
 
-    @mock.patch('spotify.connection.lib', spec=spotify.lib)
+    @mock.patch("spotify.connection.lib", spec=spotify.lib)
     def test_set_private_session(self, conn_lib_mock, session_lib_mock, lib_mock):
         lib_mock.sp_session_set_private_session.return_value = spotify.ErrorType.OK
         session = tests.create_real_session(session_lib_mock)
@@ -33,7 +33,7 @@ class SocialTest(unittest.TestCase):
             session._sp_session, 1
         )
 
-    @mock.patch('spotify.connection.lib', spec=spotify.lib)
+    @mock.patch("spotify.connection.lib", spec=spotify.lib)
     def test_set_private_session_fail_raises_error(
         self, conn_lib_mock, session_lib_mock, lib_mock
     ):
@@ -125,7 +125,7 @@ class SocialTest(unittest.TestCase):
         session = tests.create_real_session(session_lib_mock)
 
         session.social.set_social_credentials(
-            spotify.SocialProvider.LASTFM, 'alice', 'secret'
+            spotify.SocialProvider.LASTFM, "alice", "secret"
         )
 
         lib_mock.sp_session_set_social_credentials.assert_called_once_with(
@@ -138,13 +138,13 @@ class SocialTest(unittest.TestCase):
             spotify.ffi.string(
                 lib_mock.sp_session_set_social_credentials.call_args[0][2]
             ),
-            b'alice',
+            b"alice",
         )
         self.assertEqual(
             spotify.ffi.string(
                 lib_mock.sp_session_set_social_credentials.call_args[0][3]
             ),
-            b'secret',
+            b"secret",
         )
 
     def test_set_social_credentials_fail_raises_error(self, session_lib_mock, lib_mock):
@@ -153,7 +153,7 @@ class SocialTest(unittest.TestCase):
 
         with self.assertRaises(spotify.Error):
             session.social.set_social_credentials(
-                spotify.SocialProvider.LASTFM, 'alice', 'secret'
+                spotify.SocialProvider.LASTFM, "alice", "secret"
             )
 
 

--- a/tests/test_toplist.py
+++ b/tests/test_toplist.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-
 import tests
 from tests import mock
 

--- a/tests/test_toplist.py
+++ b/tests/test_toplist.py
@@ -17,20 +17,14 @@ class ToplistTest(unittest.TestCase):
         spotify._session_instance = None
 
     def assert_fails_if_error(self, lib_mock, func):
-        lib_mock.sp_toplistbrowse_error.return_value = (
-            spotify.ErrorType.BAD_API_VERSION
-        )
+        lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.BAD_API_VERSION
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         with self.assertRaises(spotify.Error):
             func(toplist)
 
-    def test_create_without_type_or_region_or_sp_toplistbrowse_fails(
-        self, lib_mock
-    ):
+    def test_create_without_type_or_region_or_sp_toplistbrowse_fails(self, lib_mock):
         with self.assertRaises(AssertionError):
             spotify.Toplist(self.session)
 
@@ -75,9 +69,7 @@ class ToplistTest(unittest.TestCase):
             mock.ANY,
         )
         self.assertEqual(
-            spotify.ffi.string(
-                lib_mock.sp_toplistbrowse_create.call_args[0][3]
-            ),
+            spotify.ffi.string(lib_mock.sp_toplistbrowse_create.call_args[0][3]),
             b'alice',
         )
 
@@ -85,9 +77,7 @@ class ToplistTest(unittest.TestCase):
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
         lib_mock.sp_toplistbrowse_create.return_value = sp_toplistbrowse
 
-        spotify.Toplist(
-            self.session, type=spotify.ToplistType.TRACKS, region='NO'
-        )
+        spotify.Toplist(self.session, type=spotify.ToplistType.TRACKS, region='NO')
 
         lib_mock.sp_toplistbrowse_create.assert_called_with(
             self.session._sp_session,
@@ -110,9 +100,7 @@ class ToplistTest(unittest.TestCase):
             callback=callback,
         )
 
-        toplistbrowse_complete_cb = lib_mock.sp_toplistbrowse_create.call_args[
-            0
-        ][4]
+        toplistbrowse_complete_cb = lib_mock.sp_toplistbrowse_create.call_args[0][4]
         userdata = lib_mock.sp_toplistbrowse_create.call_args[0][5]
         toplistbrowse_complete_cb(sp_toplistbrowse, userdata)
 
@@ -136,33 +124,25 @@ class ToplistTest(unittest.TestCase):
 
         # The mock keeps the handle/userdata alive, thus this test doesn't
         # really test that session._callback_handles keeps the handle alive.
-        toplistbrowse_complete_cb = lib_mock.sp_toplistbrowse_create.call_args[
-            0
-        ][4]
+        toplistbrowse_complete_cb = lib_mock.sp_toplistbrowse_create.call_args[0][4]
         userdata = lib_mock.sp_toplistbrowse_create.call_args[0][5]
         toplistbrowse_complete_cb(sp_toplistbrowse, userdata)
 
         loaded_event.wait(3)
         self.assertEqual(callback.call_count, 1)
-        self.assertEqual(
-            callback.call_args[0][0]._sp_toplistbrowse, sp_toplistbrowse
-        )
+        self.assertEqual(callback.call_args[0][0]._sp_toplistbrowse, sp_toplistbrowse)
 
     def test_adds_ref_to_sp_toplistbrowse_when_created(self, lib_mock):
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
 
         spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
-        lib_mock.sp_toplistbrowse_add_ref.assert_called_once_with(
-            sp_toplistbrowse
-        )
+        lib_mock.sp_toplistbrowse_add_ref.assert_called_once_with(sp_toplistbrowse)
 
     def test_releases_sp_toplistbrowse_when_toplist_dies(self, lib_mock):
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
 
-        toplist = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
         toplist = None  # noqa
         tests.gc_collect()
 
@@ -185,58 +165,40 @@ class ToplistTest(unittest.TestCase):
 
     def test_eq(self, lib_mock):
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist1 = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
-        toplist2 = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist1 = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
+        toplist2 = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         self.assertTrue(toplist1 == toplist2)
         self.assertFalse(toplist1 == 'foo')
 
     def test_ne(self, lib_mock):
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist1 = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
-        toplist2 = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist1 = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
+        toplist2 = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         self.assertFalse(toplist1 != toplist2)
 
     def test_hash(self, lib_mock):
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist1 = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
-        toplist2 = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist1 = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
+        toplist2 = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         self.assertEqual(hash(toplist1), hash(toplist2))
 
     def test_is_loaded(self, lib_mock):
         lib_mock.sp_toplistbrowse_is_loaded.return_value = 1
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.is_loaded
 
-        lib_mock.sp_toplistbrowse_is_loaded.assert_called_once_with(
-            sp_toplistbrowse
-        )
+        lib_mock.sp_toplistbrowse_is_loaded.assert_called_once_with(sp_toplistbrowse)
         self.assertTrue(result)
 
     @mock.patch('spotify.utils.load')
     def test_load(self, load_mock, lib_mock):
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         toplist.load(10)
 
@@ -247,23 +209,17 @@ class ToplistTest(unittest.TestCase):
             spotify.ErrorType.OTHER_PERMANENT
         )
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.error
 
-        lib_mock.sp_toplistbrowse_error.assert_called_once_with(
-            sp_toplistbrowse
-        )
+        lib_mock.sp_toplistbrowse_error.assert_called_once_with(sp_toplistbrowse)
         self.assertIs(result, spotify.ErrorType.OTHER_PERMANENT)
 
     def test_backend_request_duration(self, lib_mock):
         lib_mock.sp_toplistbrowse_backend_request_duration.return_value = 137
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.backend_request_duration
 
@@ -275,9 +231,7 @@ class ToplistTest(unittest.TestCase):
     def test_backend_request_duration_when_not_loaded(self, lib_mock):
         lib_mock.sp_toplistbrowse_is_loaded.return_value = 0
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.backend_request_duration
 
@@ -294,18 +248,14 @@ class ToplistTest(unittest.TestCase):
         lib_mock.sp_toplistbrowse_num_tracks.return_value = 1
         lib_mock.sp_toplistbrowse_track.return_value = sp_track
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         self.assertEqual(lib_mock.sp_toplistbrowse_add_ref.call_count, 1)
         result = toplist.tracks
         self.assertEqual(lib_mock.sp_toplistbrowse_add_ref.call_count, 2)
 
         self.assertEqual(len(result), 1)
-        lib_mock.sp_toplistbrowse_num_tracks.assert_called_with(
-            sp_toplistbrowse
-        )
+        lib_mock.sp_toplistbrowse_num_tracks.assert_called_with(sp_toplistbrowse)
 
         item = result[0]
         self.assertIsInstance(item, spotify.Track)
@@ -318,25 +268,19 @@ class ToplistTest(unittest.TestCase):
         lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_toplistbrowse_num_tracks.return_value = 0
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.tracks
 
         self.assertEqual(len(result), 0)
-        lib_mock.sp_toplistbrowse_num_tracks.assert_called_with(
-            sp_toplistbrowse
-        )
+        lib_mock.sp_toplistbrowse_num_tracks.assert_called_with(sp_toplistbrowse)
         self.assertEqual(lib_mock.sp_toplistbrowse_track.call_count, 0)
 
     def test_tracks_if_unloaded(self, lib_mock):
         lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_toplistbrowse_is_loaded.return_value = 0
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.tracks
 
@@ -353,18 +297,14 @@ class ToplistTest(unittest.TestCase):
         lib_mock.sp_toplistbrowse_num_albums.return_value = 1
         lib_mock.sp_toplistbrowse_album.return_value = sp_album
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         self.assertEqual(lib_mock.sp_toplistbrowse_add_ref.call_count, 1)
         result = toplist.albums
         self.assertEqual(lib_mock.sp_toplistbrowse_add_ref.call_count, 2)
 
         self.assertEqual(len(result), 1)
-        lib_mock.sp_toplistbrowse_num_albums.assert_called_with(
-            sp_toplistbrowse
-        )
+        lib_mock.sp_toplistbrowse_num_albums.assert_called_with(sp_toplistbrowse)
 
         item = result[0]
         self.assertIsInstance(item, spotify.Album)
@@ -377,25 +317,19 @@ class ToplistTest(unittest.TestCase):
         lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_toplistbrowse_num_albums.return_value = 0
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.albums
 
         self.assertEqual(len(result), 0)
-        lib_mock.sp_toplistbrowse_num_albums.assert_called_with(
-            sp_toplistbrowse
-        )
+        lib_mock.sp_toplistbrowse_num_albums.assert_called_with(sp_toplistbrowse)
         self.assertEqual(lib_mock.sp_toplistbrowse_album.call_count, 0)
 
     def test_albums_if_unloaded(self, lib_mock):
         lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_toplistbrowse_is_loaded.return_value = 0
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.albums
 
@@ -412,18 +346,14 @@ class ToplistTest(unittest.TestCase):
         lib_mock.sp_toplistbrowse_num_artists.return_value = 1
         lib_mock.sp_toplistbrowse_artist.return_value = sp_artist
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         self.assertEqual(lib_mock.sp_toplistbrowse_add_ref.call_count, 1)
         result = toplist.artists
         self.assertEqual(lib_mock.sp_toplistbrowse_add_ref.call_count, 2)
 
         self.assertEqual(len(result), 1)
-        lib_mock.sp_toplistbrowse_num_artists.assert_called_with(
-            sp_toplistbrowse
-        )
+        lib_mock.sp_toplistbrowse_num_artists.assert_called_with(sp_toplistbrowse)
 
         item = result[0]
         self.assertIsInstance(item, spotify.Artist)
@@ -436,25 +366,19 @@ class ToplistTest(unittest.TestCase):
         lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_toplistbrowse_num_artists.return_value = 0
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.artists
 
         self.assertEqual(len(result), 0)
-        lib_mock.sp_toplistbrowse_num_artists.assert_called_with(
-            sp_toplistbrowse
-        )
+        lib_mock.sp_toplistbrowse_num_artists.assert_called_with(sp_toplistbrowse)
         self.assertEqual(lib_mock.sp_toplistbrowse_artist.call_count, 0)
 
     def test_artists_if_unloaded(self, lib_mock):
         lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_toplistbrowse_is_loaded.return_value = 0
         sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
-        toplist = spotify.Toplist(
-            self.session, sp_toplistbrowse=sp_toplistbrowse
-        )
+        toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.artists
 

--- a/tests/test_toplist.py
+++ b/tests/test_toplist.py
@@ -7,7 +7,7 @@ import tests
 from tests import mock
 
 
-@mock.patch('spotify.toplist.lib', spec=spotify.lib)
+@mock.patch("spotify.toplist.lib", spec=spotify.lib)
 class ToplistTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
@@ -18,7 +18,7 @@ class ToplistTest(unittest.TestCase):
 
     def assert_fails_if_error(self, lib_mock, func):
         lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.BAD_API_VERSION
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         with self.assertRaises(spotify.Error):
@@ -29,7 +29,7 @@ class ToplistTest(unittest.TestCase):
             spotify.Toplist(self.session)
 
     def test_create_from_type_and_current_user_region(self, lib_mock):
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         lib_mock.sp_toplistbrowse_create.return_value = sp_toplistbrowse
 
         result = spotify.Toplist(
@@ -50,14 +50,14 @@ class ToplistTest(unittest.TestCase):
         self.assertEqual(result._sp_toplistbrowse, sp_toplistbrowse)
 
     def test_create_from_type_and_specific_user_region(self, lib_mock):
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         lib_mock.sp_toplistbrowse_create.return_value = sp_toplistbrowse
 
         spotify.Toplist(
             self.session,
             type=spotify.ToplistType.TRACKS,
             region=spotify.ToplistRegion.USER,
-            canonical_username='alice',
+            canonical_username="alice",
         )
 
         lib_mock.sp_toplistbrowse_create.assert_called_with(
@@ -70,14 +70,14 @@ class ToplistTest(unittest.TestCase):
         )
         self.assertEqual(
             spotify.ffi.string(lib_mock.sp_toplistbrowse_create.call_args[0][3]),
-            b'alice',
+            b"alice",
         )
 
     def test_create_from_type_and_country(self, lib_mock):
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         lib_mock.sp_toplistbrowse_create.return_value = sp_toplistbrowse
 
-        spotify.Toplist(self.session, type=spotify.ToplistType.TRACKS, region='NO')
+        spotify.Toplist(self.session, type=spotify.ToplistType.TRACKS, region="NO")
 
         lib_mock.sp_toplistbrowse_create.assert_called_with(
             self.session._sp_session,
@@ -89,7 +89,7 @@ class ToplistTest(unittest.TestCase):
         )
 
     def test_create_with_callback(self, lib_mock):
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         lib_mock.sp_toplistbrowse_create.return_value = sp_toplistbrowse
         callback = mock.Mock()
 
@@ -108,7 +108,7 @@ class ToplistTest(unittest.TestCase):
         callback.assert_called_with(result)
 
     def test_toplist_is_gone_before_callback_is_called(self, lib_mock):
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         lib_mock.sp_toplistbrowse_create.return_value = sp_toplistbrowse
         callback = mock.Mock()
 
@@ -133,14 +133,14 @@ class ToplistTest(unittest.TestCase):
         self.assertEqual(callback.call_args[0][0]._sp_toplistbrowse, sp_toplistbrowse)
 
     def test_adds_ref_to_sp_toplistbrowse_when_created(self, lib_mock):
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
 
         spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         lib_mock.sp_toplistbrowse_add_ref.assert_called_once_with(sp_toplistbrowse)
 
     def test_releases_sp_toplistbrowse_when_toplist_dies(self, lib_mock):
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
 
         toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
         toplist = None  # noqa
@@ -149,10 +149,10 @@ class ToplistTest(unittest.TestCase):
         lib_mock.sp_toplistbrowse_release.assert_called_with(sp_toplistbrowse)
 
     def test_repr(self, lib_mock):
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         lib_mock.sp_toplistbrowse_create.return_value = sp_toplistbrowse
         toplist = spotify.Toplist(
-            self.session, type=spotify.ToplistType.TRACKS, region='NO'
+            self.session, type=spotify.ToplistType.TRACKS, region="NO"
         )
 
         result = repr(toplist)
@@ -160,26 +160,26 @@ class ToplistTest(unittest.TestCase):
         self.assertEqual(
             result,
             "Toplist(type=<ToplistType.TRACKS: 2>, region=%r, "
-            "canonical_username=None)" % 'NO',
+            "canonical_username=None)" % "NO",
         )
 
     def test_eq(self, lib_mock):
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist1 = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
         toplist2 = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         self.assertTrue(toplist1 == toplist2)
-        self.assertFalse(toplist1 == 'foo')
+        self.assertFalse(toplist1 == "foo")
 
     def test_ne(self, lib_mock):
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist1 = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
         toplist2 = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         self.assertFalse(toplist1 != toplist2)
 
     def test_hash(self, lib_mock):
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist1 = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
         toplist2 = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
@@ -187,7 +187,7 @@ class ToplistTest(unittest.TestCase):
 
     def test_is_loaded(self, lib_mock):
         lib_mock.sp_toplistbrowse_is_loaded.return_value = 1
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.is_loaded
@@ -195,9 +195,9 @@ class ToplistTest(unittest.TestCase):
         lib_mock.sp_toplistbrowse_is_loaded.assert_called_once_with(sp_toplistbrowse)
         self.assertTrue(result)
 
-    @mock.patch('spotify.utils.load')
+    @mock.patch("spotify.utils.load")
     def test_load(self, load_mock, lib_mock):
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         toplist.load(10)
@@ -208,7 +208,7 @@ class ToplistTest(unittest.TestCase):
         lib_mock.sp_toplistbrowse_error.return_value = int(
             spotify.ErrorType.OTHER_PERMANENT
         )
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.error
@@ -218,7 +218,7 @@ class ToplistTest(unittest.TestCase):
 
     def test_backend_request_duration(self, lib_mock):
         lib_mock.sp_toplistbrowse_backend_request_duration.return_value = 137
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.backend_request_duration
@@ -230,7 +230,7 @@ class ToplistTest(unittest.TestCase):
 
     def test_backend_request_duration_when_not_loaded(self, lib_mock):
         lib_mock.sp_toplistbrowse_is_loaded.return_value = 0
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.backend_request_duration
@@ -241,13 +241,13 @@ class ToplistTest(unittest.TestCase):
         )
         self.assertIsNone(result)
 
-    @mock.patch('spotify.track.lib', spec=spotify.lib)
+    @mock.patch("spotify.track.lib", spec=spotify.lib)
     def test_tracks(self, track_lib_mock, lib_mock):
         lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.OK
-        sp_track = spotify.ffi.cast('sp_track *', 43)
+        sp_track = spotify.ffi.cast("sp_track *", 43)
         lib_mock.sp_toplistbrowse_num_tracks.return_value = 1
         lib_mock.sp_toplistbrowse_track.return_value = sp_track
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         self.assertEqual(lib_mock.sp_toplistbrowse_add_ref.call_count, 1)
@@ -267,7 +267,7 @@ class ToplistTest(unittest.TestCase):
     def test_tracks_if_no_tracks(self, lib_mock):
         lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_toplistbrowse_num_tracks.return_value = 0
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.tracks
@@ -279,7 +279,7 @@ class ToplistTest(unittest.TestCase):
     def test_tracks_if_unloaded(self, lib_mock):
         lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_toplistbrowse_is_loaded.return_value = 0
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.tracks
@@ -290,13 +290,13 @@ class ToplistTest(unittest.TestCase):
     def test_tracks_fails_if_error(self, lib_mock):
         self.assert_fails_if_error(lib_mock, lambda s: s.tracks)
 
-    @mock.patch('spotify.album.lib', spec=spotify.lib)
+    @mock.patch("spotify.album.lib", spec=spotify.lib)
     def test_albums(self, album_lib_mock, lib_mock):
         lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.OK
-        sp_album = spotify.ffi.cast('sp_album *', 43)
+        sp_album = spotify.ffi.cast("sp_album *", 43)
         lib_mock.sp_toplistbrowse_num_albums.return_value = 1
         lib_mock.sp_toplistbrowse_album.return_value = sp_album
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         self.assertEqual(lib_mock.sp_toplistbrowse_add_ref.call_count, 1)
@@ -316,7 +316,7 @@ class ToplistTest(unittest.TestCase):
     def test_albums_if_no_albums(self, lib_mock):
         lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_toplistbrowse_num_albums.return_value = 0
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.albums
@@ -328,7 +328,7 @@ class ToplistTest(unittest.TestCase):
     def test_albums_if_unloaded(self, lib_mock):
         lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_toplistbrowse_is_loaded.return_value = 0
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.albums
@@ -339,13 +339,13 @@ class ToplistTest(unittest.TestCase):
     def test_albums_fails_if_error(self, lib_mock):
         self.assert_fails_if_error(lib_mock, lambda s: s.albums)
 
-    @mock.patch('spotify.artist.lib', spec=spotify.lib)
+    @mock.patch("spotify.artist.lib", spec=spotify.lib)
     def test_artists(self, artist_lib_mock, lib_mock):
         lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.OK
-        sp_artist = spotify.ffi.cast('sp_artist *', 43)
+        sp_artist = spotify.ffi.cast("sp_artist *", 43)
         lib_mock.sp_toplistbrowse_num_artists.return_value = 1
         lib_mock.sp_toplistbrowse_artist.return_value = sp_artist
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         self.assertEqual(lib_mock.sp_toplistbrowse_add_ref.call_count, 1)
@@ -365,7 +365,7 @@ class ToplistTest(unittest.TestCase):
     def test_artists_if_no_artists(self, lib_mock):
         lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_toplistbrowse_num_artists.return_value = 0
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.artists
@@ -377,7 +377,7 @@ class ToplistTest(unittest.TestCase):
     def test_artists_if_unloaded(self, lib_mock):
         lib_mock.sp_toplistbrowse_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_toplistbrowse_is_loaded.return_value = 0
-        sp_toplistbrowse = spotify.ffi.cast('sp_toplistbrowse *', 42)
+        sp_toplistbrowse = spotify.ffi.cast("sp_toplistbrowse *", 42)
         toplist = spotify.Toplist(self.session, sp_toplistbrowse=sp_toplistbrowse)
 
         result = toplist.artists

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -334,9 +334,7 @@ class TrackTest(unittest.TestCase):
 
     def test_set_starred_fails_if_error(self, lib_mock):
         tests.create_session_mock()
-        lib_mock.sp_track_set_starred.return_value = (
-            spotify.ErrorType.BAD_API_VERSION
-        )
+        lib_mock.sp_track_set_starred.return_value = spotify.ErrorType.BAD_API_VERSION
         sp_track = spotify.ffi.cast('sp_track *', 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
@@ -422,9 +420,7 @@ class TrackTest(unittest.TestCase):
 
     def test_name(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.OK
-        lib_mock.sp_track_name.return_value = spotify.ffi.new(
-            'char[]', b'Foo Bar Baz'
-        )
+        lib_mock.sp_track_name.return_value = spotify.ffi.new('char[]', b'Foo Bar Baz')
         sp_track = spotify.ffi.cast('sp_track *', 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
@@ -559,9 +555,7 @@ class TrackTest(unittest.TestCase):
         result = track.link
 
         lib_mock.sp_link_create_from_track.asssert_called_once_with(sp_track, 0)
-        link_mock.assert_called_once_with(
-            self.session, sp_link=sp_link, add_ref=False
-        )
+        link_mock.assert_called_once_with(self.session, sp_link=sp_link, add_ref=False)
         self.assertEqual(result, mock.sentinel.link)
 
     @mock.patch('spotify.Link', spec=spotify.Link)
@@ -574,12 +568,8 @@ class TrackTest(unittest.TestCase):
 
         result = track.link_with_offset(90)
 
-        lib_mock.sp_link_create_from_track.asssert_called_once_with(
-            sp_track, 90
-        )
-        link_mock.assert_called_once_with(
-            self.session, sp_link=sp_link, add_ref=False
-        )
+        lib_mock.sp_link_create_from_track.asssert_called_once_with(sp_track, 90)
+        link_mock.assert_called_once_with(self.session, sp_link=sp_link, add_ref=False)
         self.assertEqual(result, mock.sentinel.link)
 
 

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-
 import tests
 from tests import mock
 

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -7,14 +7,14 @@ import tests
 from tests import mock
 
 
-@mock.patch('spotify.track.lib', spec=spotify.lib)
+@mock.patch("spotify.track.lib", spec=spotify.lib)
 class TrackTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
 
     def assert_fails_if_error(self, lib_mock, func):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.BAD_API_VERSION
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         with self.assertRaises(spotify.Error):
@@ -24,14 +24,14 @@ class TrackTest(unittest.TestCase):
         with self.assertRaises(AssertionError):
             spotify.Track(self.session)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_create_from_uri(self, link_mock, lib_mock):
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         link_instance_mock = link_mock.return_value
         link_instance_mock.as_track.return_value = spotify.Track(
             self.session, sp_track=sp_track
         )
-        uri = 'spotify:track:foo'
+        uri = "spotify:track:foo"
 
         result = spotify.Track(self.session, uri=uri)
 
@@ -40,24 +40,24 @@ class TrackTest(unittest.TestCase):
         lib_mock.sp_track_add_ref.assert_called_with(sp_track)
         self.assertEqual(result._sp_track, sp_track)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_create_from_uri_fail_raises_error(self, link_mock, lib_mock):
         link_instance_mock = link_mock.return_value
         link_instance_mock.as_track.return_value = None
-        uri = 'spotify:track:foo'
+        uri = "spotify:track:foo"
 
         with self.assertRaises(ValueError):
             spotify.Track(self.session, uri=uri)
 
     def test_adds_ref_to_sp_track_when_created(self, lib_mock):
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
 
         spotify.Track(self.session, sp_track=sp_track)
 
         lib_mock.sp_track_add_ref.assert_called_with(sp_track)
 
     def test_releases_sp_track_when_track_dies(self, lib_mock):
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
 
         track = spotify.Track(self.session, sp_track=sp_track)
         track = None  # noqa
@@ -65,34 +65,34 @@ class TrackTest(unittest.TestCase):
 
         lib_mock.sp_track_release.assert_called_with(sp_track)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_repr(self, link_mock, lib_mock):
         link_instance_mock = link_mock.return_value
-        link_instance_mock.uri = 'foo'
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        link_instance_mock.uri = "foo"
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = repr(track)
 
-        self.assertEqual(result, 'Track(%r)' % 'foo')
+        self.assertEqual(result, "Track(%r)" % "foo")
 
     def test_eq(self, lib_mock):
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track1 = spotify.Track(self.session, sp_track=sp_track)
         track2 = spotify.Track(self.session, sp_track=sp_track)
 
         self.assertTrue(track1 == track2)
-        self.assertFalse(track1 == 'foo')
+        self.assertFalse(track1 == "foo")
 
     def test_ne(self, lib_mock):
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track1 = spotify.Track(self.session, sp_track=sp_track)
         track2 = spotify.Track(self.session, sp_track=sp_track)
 
         self.assertFalse(track1 != track2)
 
     def test_hash(self, lib_mock):
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track1 = spotify.Track(self.session, sp_track=sp_track)
         track2 = spotify.Track(self.session, sp_track=sp_track)
 
@@ -100,7 +100,7 @@ class TrackTest(unittest.TestCase):
 
     def test_is_loaded(self, lib_mock):
         lib_mock.sp_track_is_loaded.return_value = 1
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.is_loaded
@@ -110,7 +110,7 @@ class TrackTest(unittest.TestCase):
 
     def test_error(self, lib_mock):
         lib_mock.sp_track_error.return_value = int(spotify.ErrorType.IS_LOADING)
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.error
@@ -118,9 +118,9 @@ class TrackTest(unittest.TestCase):
         lib_mock.sp_track_error.assert_called_once_with(sp_track)
         self.assertIs(result, spotify.ErrorType.IS_LOADING)
 
-    @mock.patch('spotify.utils.load')
+    @mock.patch("spotify.utils.load")
     def test_load(self, load_mock, lib_mock):
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         track.load(10)
@@ -130,7 +130,7 @@ class TrackTest(unittest.TestCase):
     def test_offline_status(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_track_offline_get_status.return_value = 2
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.offline_status
@@ -141,7 +141,7 @@ class TrackTest(unittest.TestCase):
     def test_offline_status_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_track_is_loaded.return_value = 0
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.offline_status
@@ -152,7 +152,7 @@ class TrackTest(unittest.TestCase):
     def test_offline_status_fails_if_error(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.BAD_API_VERSION
         lib_mock.sp_track_offline_get_status.return_value = 2
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         with self.assertRaises(spotify.Error):
@@ -161,7 +161,7 @@ class TrackTest(unittest.TestCase):
     def test_availability(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_track_get_availability.return_value = 1
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.availability
@@ -174,7 +174,7 @@ class TrackTest(unittest.TestCase):
     def test_availability_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_track_is_loaded.return_value = 0
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.availability
@@ -188,7 +188,7 @@ class TrackTest(unittest.TestCase):
     def test_is_local(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_track_is_local.return_value = 1
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.is_local
@@ -201,7 +201,7 @@ class TrackTest(unittest.TestCase):
     def test_is_local_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_track_is_loaded.return_value = 0
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.is_local
@@ -215,7 +215,7 @@ class TrackTest(unittest.TestCase):
     def test_is_autolinked(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_track_is_autolinked.return_value = 1
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.is_autolinked
@@ -228,7 +228,7 @@ class TrackTest(unittest.TestCase):
     def test_is_autolinked_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_track_is_loaded.return_value = 0
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.is_autolinked
@@ -241,9 +241,9 @@ class TrackTest(unittest.TestCase):
 
     def test_playable(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.OK
-        sp_track_playable = spotify.ffi.cast('sp_track *', 43)
+        sp_track_playable = spotify.ffi.cast("sp_track *", 43)
         lib_mock.sp_track_get_playable.return_value = sp_track_playable
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.playable
@@ -258,7 +258,7 @@ class TrackTest(unittest.TestCase):
     def test_playable_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_track_is_loaded.return_value = 0
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.playable
@@ -272,7 +272,7 @@ class TrackTest(unittest.TestCase):
     def test_is_placeholder(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_track_is_placeholder.return_value = 1
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.is_placeholder
@@ -283,7 +283,7 @@ class TrackTest(unittest.TestCase):
     def test_is_placeholder_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_track_is_loaded.return_value = 0
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.is_placeholder
@@ -297,7 +297,7 @@ class TrackTest(unittest.TestCase):
     def test_is_starred(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_track_is_starred.return_value = 1
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.starred
@@ -310,7 +310,7 @@ class TrackTest(unittest.TestCase):
     def test_is_starred_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_track_is_loaded.return_value = 0
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.starred
@@ -323,7 +323,7 @@ class TrackTest(unittest.TestCase):
 
     def test_set_starred(self, lib_mock):
         lib_mock.sp_track_set_starred.return_value = spotify.ErrorType.OK
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         track.starred = True
@@ -335,19 +335,19 @@ class TrackTest(unittest.TestCase):
     def test_set_starred_fails_if_error(self, lib_mock):
         tests.create_session_mock()
         lib_mock.sp_track_set_starred.return_value = spotify.ErrorType.BAD_API_VERSION
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         with self.assertRaises(spotify.Error):
             track.starred = True
 
-    @mock.patch('spotify.artist.lib', spec=spotify.lib)
+    @mock.patch("spotify.artist.lib", spec=spotify.lib)
     def test_artists(self, artist_lib_mock, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.OK
-        sp_artist = spotify.ffi.cast('sp_artist *', 43)
+        sp_artist = spotify.ffi.cast("sp_artist *", 43)
         lib_mock.sp_track_num_artists.return_value = 1
         lib_mock.sp_track_artist.return_value = sp_artist
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.artists
@@ -365,7 +365,7 @@ class TrackTest(unittest.TestCase):
     def test_artists_if_no_artists(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_track_num_artists.return_value = 0
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.artists
@@ -377,7 +377,7 @@ class TrackTest(unittest.TestCase):
     def test_artists_if_unloaded(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_track_is_loaded.return_value = 0
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.artists
@@ -388,12 +388,12 @@ class TrackTest(unittest.TestCase):
     def test_artists_fails_if_error(self, lib_mock):
         self.assert_fails_if_error(lib_mock, lambda t: t.artists)
 
-    @mock.patch('spotify.album.lib', spec=spotify.lib)
+    @mock.patch("spotify.album.lib", spec=spotify.lib)
     def test_album(self, album_lib_mock, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.OK
-        sp_album = spotify.ffi.cast('sp_album *', 43)
+        sp_album = spotify.ffi.cast("sp_album *", 43)
         lib_mock.sp_track_album.return_value = sp_album
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.album
@@ -403,11 +403,11 @@ class TrackTest(unittest.TestCase):
         self.assertIsInstance(result, spotify.Album)
         self.assertEqual(result._sp_album, sp_album)
 
-    @mock.patch('spotify.album.lib', spec=spotify.lib)
+    @mock.patch("spotify.album.lib", spec=spotify.lib)
     def test_album_if_unloaded(self, album_lib_mock, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_track_is_loaded.return_value = 0
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.album
@@ -420,20 +420,20 @@ class TrackTest(unittest.TestCase):
 
     def test_name(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.OK
-        lib_mock.sp_track_name.return_value = spotify.ffi.new('char[]', b'Foo Bar Baz')
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        lib_mock.sp_track_name.return_value = spotify.ffi.new("char[]", b"Foo Bar Baz")
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.name
 
         lib_mock.sp_track_name.assert_called_once_with(sp_track)
-        self.assertEqual(result, 'Foo Bar Baz')
+        self.assertEqual(result, "Foo Bar Baz")
 
     def test_name_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_track_is_loaded.return_value = 0
-        lib_mock.sp_track_name.return_value = spotify.ffi.new('char[]', b'')
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        lib_mock.sp_track_name.return_value = spotify.ffi.new("char[]", b"")
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.name
@@ -447,7 +447,7 @@ class TrackTest(unittest.TestCase):
     def test_duration(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_track_duration.return_value = 60000
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.duration
@@ -458,7 +458,7 @@ class TrackTest(unittest.TestCase):
     def test_duration_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_track_is_loaded.return_value = 0
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.duration
@@ -472,7 +472,7 @@ class TrackTest(unittest.TestCase):
     def test_popularity(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_track_popularity.return_value = 90
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.popularity
@@ -483,7 +483,7 @@ class TrackTest(unittest.TestCase):
     def test_popularity_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_track_is_loaded.return_value = 0
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.popularity
@@ -497,7 +497,7 @@ class TrackTest(unittest.TestCase):
     def test_disc(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_track_disc.return_value = 2
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.disc
@@ -508,7 +508,7 @@ class TrackTest(unittest.TestCase):
     def test_disc_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_track_is_loaded.return_value = 0
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.disc
@@ -522,7 +522,7 @@ class TrackTest(unittest.TestCase):
     def test_index(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.OK
         lib_mock.sp_track_index.return_value = 7
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.index
@@ -533,7 +533,7 @@ class TrackTest(unittest.TestCase):
     def test_index_is_none_if_unloaded(self, lib_mock):
         lib_mock.sp_track_error.return_value = spotify.ErrorType.IS_LOADING
         lib_mock.sp_track_is_loaded.return_value = 0
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
 
         result = track.index
@@ -544,11 +544,11 @@ class TrackTest(unittest.TestCase):
     def test_index_fails_if_error(self, lib_mock):
         self.assert_fails_if_error(lib_mock, lambda t: t.index)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_link_creates_link_to_track(self, link_mock, lib_mock):
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
-        sp_link = spotify.ffi.cast('sp_link *', 43)
+        sp_link = spotify.ffi.cast("sp_link *", 43)
         lib_mock.sp_link_create_from_track.return_value = sp_link
         link_mock.return_value = mock.sentinel.link
 
@@ -558,11 +558,11 @@ class TrackTest(unittest.TestCase):
         link_mock.assert_called_once_with(self.session, sp_link=sp_link, add_ref=False)
         self.assertEqual(result, mock.sentinel.link)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_link_with_offset(self, link_mock, lib_mock):
-        sp_track = spotify.ffi.cast('sp_track *', 42)
+        sp_track = spotify.ffi.cast("sp_track *", 42)
         track = spotify.Track(self.session, sp_track=sp_track)
-        sp_link = spotify.ffi.cast('sp_link *', 43)
+        sp_link = spotify.ffi.cast("sp_link *", 43)
         lib_mock.sp_link_create_from_track.return_value = sp_link
         link_mock.return_value = mock.sentinel.link
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -121,9 +121,7 @@ class UserTest(unittest.TestCase):
 
         result = user.link
 
-        link_mock.assert_called_once_with(
-            self.session, sp_link=sp_link, add_ref=False
-        )
+        link_mock.assert_called_once_with(self.session, sp_link=sp_link, add_ref=False)
         self.assertEqual(result, mock.sentinel.link)
 
     def test_starred(self, lib_mock):

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -7,7 +7,7 @@ import tests
 from tests import mock
 
 
-@mock.patch('spotify.user.lib', spec=spotify.lib)
+@mock.patch("spotify.user.lib", spec=spotify.lib)
 class UserTest(unittest.TestCase):
     def setUp(self):
         self.session = tests.create_session_mock()
@@ -16,14 +16,14 @@ class UserTest(unittest.TestCase):
         with self.assertRaises(AssertionError):
             spotify.User(self.session)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_create_from_uri(self, link_mock, lib_mock):
-        sp_user = spotify.ffi.cast('sp_user *', 42)
+        sp_user = spotify.ffi.cast("sp_user *", 42)
         link_instance_mock = link_mock.return_value
         link_instance_mock.as_user.return_value = spotify.User(
             self.session, sp_user=sp_user
         )
-        uri = 'spotify:user:foo'
+        uri = "spotify:user:foo"
 
         result = spotify.User(self.session, uri=uri)
 
@@ -32,24 +32,24 @@ class UserTest(unittest.TestCase):
         lib_mock.sp_user_add_ref.assert_called_with(sp_user)
         self.assertEqual(result._sp_user, sp_user)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_create_from_uri_fail_raises_error(self, link_mock, lib_mock):
         link_instance_mock = link_mock.return_value
         link_instance_mock.as_user.return_value = None
-        uri = 'spotify:user:foo'
+        uri = "spotify:user:foo"
 
         with self.assertRaises(ValueError):
             spotify.User(self.session, uri=uri)
 
     def test_adds_ref_to_sp_user_when_created(self, lib_mock):
-        sp_user = spotify.ffi.cast('sp_user *', 42)
+        sp_user = spotify.ffi.cast("sp_user *", 42)
 
         spotify.User(self.session, sp_user=sp_user)
 
         lib_mock.sp_user_add_ref.assert_called_once_with(sp_user)
 
     def test_releases_sp_user_when_user_dies(self, lib_mock):
-        sp_user = spotify.ffi.cast('sp_user *', 42)
+        sp_user = spotify.ffi.cast("sp_user *", 42)
 
         user = spotify.User(self.session, sp_user=sp_user)
         user = None  # noqa
@@ -57,44 +57,44 @@ class UserTest(unittest.TestCase):
 
         lib_mock.sp_user_release.assert_called_with(sp_user)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_repr(self, link_mock, lib_mock):
         link_instance_mock = link_mock.return_value
-        link_instance_mock.uri = 'foo'
-        sp_user = spotify.ffi.cast('sp_user *', 42)
+        link_instance_mock.uri = "foo"
+        sp_user = spotify.ffi.cast("sp_user *", 42)
         user = spotify.User(self.session, sp_user=sp_user)
 
         result = repr(user)
 
-        self.assertEqual(result, 'User(%r)' % 'foo')
+        self.assertEqual(result, "User(%r)" % "foo")
 
     def test_canonical_name(self, lib_mock):
         lib_mock.sp_user_canonical_name.return_value = spotify.ffi.new(
-            'char[]', b'alicefoobar'
+            "char[]", b"alicefoobar"
         )
-        sp_user = spotify.ffi.cast('sp_user *', 42)
+        sp_user = spotify.ffi.cast("sp_user *", 42)
         user = spotify.User(self.session, sp_user=sp_user)
 
         result = user.canonical_name
 
         lib_mock.sp_user_canonical_name.assert_called_once_with(sp_user)
-        self.assertEqual(result, 'alicefoobar')
+        self.assertEqual(result, "alicefoobar")
 
     def test_display_name(self, lib_mock):
         lib_mock.sp_user_display_name.return_value = spotify.ffi.new(
-            'char[]', b'Alice Foobar'
+            "char[]", b"Alice Foobar"
         )
-        sp_user = spotify.ffi.cast('sp_user *', 42)
+        sp_user = spotify.ffi.cast("sp_user *", 42)
         user = spotify.User(self.session, sp_user=sp_user)
 
         result = user.display_name
 
         lib_mock.sp_user_display_name.assert_called_once_with(sp_user)
-        self.assertEqual(result, 'Alice Foobar')
+        self.assertEqual(result, "Alice Foobar")
 
     def test_is_loaded(self, lib_mock):
         lib_mock.sp_user_is_loaded.return_value = 1
-        sp_user = spotify.ffi.cast('sp_user *', 42)
+        sp_user = spotify.ffi.cast("sp_user *", 42)
         user = spotify.User(self.session, sp_user=sp_user)
 
         result = user.is_loaded
@@ -102,20 +102,20 @@ class UserTest(unittest.TestCase):
         lib_mock.sp_user_is_loaded.assert_called_once_with(sp_user)
         self.assertTrue(result)
 
-    @mock.patch('spotify.utils.load')
+    @mock.patch("spotify.utils.load")
     def test_load(self, load_mock, lib_mock):
-        sp_user = spotify.ffi.cast('sp_user *', 42)
+        sp_user = spotify.ffi.cast("sp_user *", 42)
         user = spotify.User(self.session, sp_user=sp_user)
 
         user.load(10)
 
         load_mock.assert_called_with(self.session, user, timeout=10)
 
-    @mock.patch('spotify.Link', spec=spotify.Link)
+    @mock.patch("spotify.Link", spec=spotify.Link)
     def test_link_creates_link_to_user(self, link_mock, lib_mock):
-        sp_user = spotify.ffi.cast('sp_user *', 42)
+        sp_user = spotify.ffi.cast("sp_user *", 42)
         user = spotify.User(self.session, sp_user=sp_user)
-        sp_link = spotify.ffi.cast('sp_link *', 43)
+        sp_link = spotify.ffi.cast("sp_link *", 43)
         lib_mock.sp_link_create_from_user.return_value = sp_link
         link_mock.return_value = mock.sentinel.link
 
@@ -127,14 +127,14 @@ class UserTest(unittest.TestCase):
     def test_starred(self, lib_mock):
         self.session.get_starred.return_value = mock.sentinel.playlist
         lib_mock.sp_user_canonical_name.return_value = spotify.ffi.new(
-            'char[]', b'alice'
+            "char[]", b"alice"
         )
-        sp_user = spotify.ffi.cast('sp_user *', 42)
+        sp_user = spotify.ffi.cast("sp_user *", 42)
         user = spotify.User(self.session, sp_user=sp_user)
 
         result = user.starred
 
-        self.session.get_starred.assert_called_with('alice')
+        self.session.get_starred.assert_called_with("alice")
         self.assertEqual(result, mock.sentinel.playlist)
 
     def test_published_playlists(self, lib_mock):
@@ -142,12 +142,12 @@ class UserTest(unittest.TestCase):
             mock.sentinel.playlist_container
         )
         lib_mock.sp_user_canonical_name.return_value = spotify.ffi.new(
-            'char[]', b'alice'
+            "char[]", b"alice"
         )
-        sp_user = spotify.ffi.cast('sp_user *', 42)
+        sp_user = spotify.ffi.cast("sp_user *", 42)
         user = spotify.User(self.session, sp_user=sp_user)
 
         result = user.published_playlists
 
-        self.session.get_published_playlists.assert_called_with('alice')
+        self.session.get_published_playlists.assert_called_with("alice")
         self.assertEqual(result, mock.sentinel.playlist_container)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-
 import tests
 from tests import mock
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -342,9 +342,7 @@ class ToBytesTest(unittest.TestCase):
         self.assertEqual(utils.to_bytes('æøå'), 'æøå'.encode('utf-8'))
 
     def test_bytes_to_bytes_is_passed_through(self):
-        self.assertEqual(
-            utils.to_bytes('æøå'.encode('utf-8')), 'æøå'.encode('utf-8')
-        )
+        self.assertEqual(utils.to_bytes('æøå'.encode('utf-8')), 'æøå'.encode('utf-8'))
 
     def test_cdata_to_bytes_is_unwrapped(self):
         cdata = spotify.ffi.new('char[]', 'æøå'.encode('utf-8'))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,43 +14,43 @@ class EventEmitterTest(unittest.TestCase):
     def test_listener_receives_event_args(self):
         listener_mock = mock.Mock()
         emitter = utils.EventEmitter()
-        emitter.on('some_event', listener_mock)
+        emitter.on("some_event", listener_mock)
 
-        emitter.emit('some_event', 'abc', 'def')
+        emitter.emit("some_event", "abc", "def")
 
-        listener_mock.assert_called_with('abc', 'def')
+        listener_mock.assert_called_with("abc", "def")
 
     def test_listener_receives_both_user_and_event_args(self):
         listener_mock = mock.Mock()
         emitter = utils.EventEmitter()
 
-        emitter.on('some_event', listener_mock, 1, 2, 3)
-        emitter.emit('some_event', 'abc')
+        emitter.on("some_event", listener_mock, 1, 2, 3)
+        emitter.emit("some_event", "abc")
 
-        listener_mock.assert_called_with('abc', 1, 2, 3)
+        listener_mock.assert_called_with("abc", 1, 2, 3)
 
     def test_multiple_listeners_for_same_event(self):
         listener_mock1 = mock.Mock()
         listener_mock2 = mock.Mock()
         emitter = utils.EventEmitter()
 
-        emitter.on('some_event', listener_mock1, 1, 2, 3)
-        emitter.on('some_event', listener_mock2, 4, 5)
-        emitter.emit('some_event', 'abc')
+        emitter.on("some_event", listener_mock1, 1, 2, 3)
+        emitter.on("some_event", listener_mock2, 4, 5)
+        emitter.emit("some_event", "abc")
 
-        listener_mock1.assert_called_with('abc', 1, 2, 3)
-        listener_mock2.assert_called_with('abc', 4, 5)
+        listener_mock1.assert_called_with("abc", 1, 2, 3)
+        listener_mock2.assert_called_with("abc", 4, 5)
 
     def test_removing_a_listener(self):
         listener_mock1 = mock.Mock()
         listener_mock2 = mock.Mock()
         emitter = utils.EventEmitter()
 
-        emitter.on('some_event', listener_mock1, 123)
-        emitter.on('some_event', listener_mock1, 456)
-        emitter.on('some_event', listener_mock2, 78)
-        emitter.off('some_event', listener_mock1)
-        emitter.emit('some_event')
+        emitter.on("some_event", listener_mock1, 123)
+        emitter.on("some_event", listener_mock1, 456)
+        emitter.on("some_event", listener_mock2, 78)
+        emitter.off("some_event", listener_mock1)
+        emitter.emit("some_event")
 
         self.assertEqual(listener_mock1.call_count, 0)
         listener_mock2.assert_called_with(78)
@@ -60,10 +60,10 @@ class EventEmitterTest(unittest.TestCase):
         listener_mock2 = mock.Mock()
         emitter = utils.EventEmitter()
 
-        emitter.on('some_event', listener_mock1)
-        emitter.on('some_event', listener_mock2)
-        emitter.off('some_event')
-        emitter.emit('some_event')
+        emitter.on("some_event", listener_mock1)
+        emitter.on("some_event", listener_mock2)
+        emitter.off("some_event")
+        emitter.emit("some_event")
 
         self.assertEqual(listener_mock1.call_count, 0)
         self.assertEqual(listener_mock2.call_count, 0)
@@ -73,11 +73,11 @@ class EventEmitterTest(unittest.TestCase):
         listener_mock2 = mock.Mock()
         emitter = utils.EventEmitter()
 
-        emitter.on('some_event', listener_mock1)
-        emitter.on('another_event', listener_mock2)
+        emitter.on("some_event", listener_mock1)
+        emitter.on("another_event", listener_mock2)
         emitter.off()
-        emitter.emit('some_event')
-        emitter.emit('another_event')
+        emitter.emit("some_event")
+        emitter.emit("another_event")
 
         self.assertEqual(listener_mock1.call_count, 0)
         self.assertEqual(listener_mock2.call_count, 0)
@@ -87,10 +87,10 @@ class EventEmitterTest(unittest.TestCase):
         listener_mock2 = mock.Mock()
         emitter = utils.EventEmitter()
 
-        emitter.on('some_event', listener_mock1)
-        emitter.on('some_event', listener_mock2)
-        emitter.emit('some_event')
-        emitter.emit('some_event')
+        emitter.on("some_event", listener_mock1)
+        emitter.on("some_event", listener_mock2)
+        emitter.emit("some_event")
+        emitter.emit("some_event")
 
         self.assertEqual(listener_mock1.call_count, 1)
         self.assertEqual(listener_mock2.call_count, 2)
@@ -102,11 +102,11 @@ class EventEmitterTest(unittest.TestCase):
 
         self.assertEqual(emitter.num_listeners(), 0)
 
-        emitter.on('some_event', listener_mock1)
+        emitter.on("some_event", listener_mock1)
         self.assertEqual(emitter.num_listeners(), 1)
 
-        emitter.on('another_event', listener_mock1)
-        emitter.on('another_event', listener_mock2)
+        emitter.on("another_event", listener_mock1)
+        emitter.on("another_event", listener_mock2)
         self.assertEqual(emitter.num_listeners(), 3)
 
     def test_num_listeners_returns_number_of_listeners_for_event(self):
@@ -114,40 +114,40 @@ class EventEmitterTest(unittest.TestCase):
         listener_mock2 = mock.Mock()
         emitter = utils.EventEmitter()
 
-        self.assertEqual(emitter.num_listeners('unknown_event'), 0)
+        self.assertEqual(emitter.num_listeners("unknown_event"), 0)
 
-        emitter.on('some_event', listener_mock1)
-        self.assertEqual(emitter.num_listeners('some_event'), 1)
+        emitter.on("some_event", listener_mock1)
+        self.assertEqual(emitter.num_listeners("some_event"), 1)
 
-        emitter.on('another_event', listener_mock1)
-        emitter.on('another_event', listener_mock2)
-        self.assertEqual(emitter.num_listeners('another_event'), 2)
+        emitter.on("another_event", listener_mock1)
+        emitter.on("another_event", listener_mock2)
+        self.assertEqual(emitter.num_listeners("another_event"), 2)
 
     def test_call_fails_if_zero_listeners_for_event(self):
         emitter = utils.EventEmitter()
 
         with self.assertRaises(AssertionError):
-            emitter.call('some_event')
+            emitter.call("some_event")
 
     def test_call_fails_if_multiple_listeners_for_event(self):
         listener_mock1 = mock.Mock()
         listener_mock2 = mock.Mock()
         emitter = utils.EventEmitter()
 
-        emitter.on('some_event', listener_mock1)
-        emitter.on('some_event', listener_mock2)
+        emitter.on("some_event", listener_mock1)
+        emitter.on("some_event", listener_mock2)
 
         with self.assertRaises(AssertionError):
-            emitter.call('some_event')
+            emitter.call("some_event")
 
     def test_call_calls_and_returns_result_of_a_single_listener(self):
         listener_mock = mock.Mock()
         emitter = utils.EventEmitter()
 
-        emitter.on('some_event', listener_mock, 1, 2, 3)
-        result = emitter.call('some_event', 'abc')
+        emitter.on("some_event", listener_mock, 1, 2, 3)
+        result = emitter.call("some_event", "abc")
 
-        listener_mock.assert_called_with('abc', 1, 2, 3)
+        listener_mock.assert_called_with("abc", 1, 2, 3)
         self.assertEqual(result, listener_mock.return_value)
 
 
@@ -158,12 +158,12 @@ class IntEnumTest(unittest.TestCase):
 
         self.Foo = Foo
 
-        self.Foo.add('bar', 1)
-        self.Foo.add('baz', 2)
+        self.Foo.add("bar", 1)
+        self.Foo.add("baz", 2)
 
     def test_has_pretty_repr(self):
-        self.assertEqual(repr(self.Foo.bar), '<Foo.bar: 1>')
-        self.assertEqual(repr(self.Foo.baz), '<Foo.baz: 2>')
+        self.assertEqual(repr(self.Foo.bar), "<Foo.bar: 1>")
+        self.assertEqual(repr(self.Foo.baz), "<Foo.baz: 2>")
 
     def test_is_equal_to_the_int_value(self):
         self.assertEqual(self.Foo.bar, 1)
@@ -176,10 +176,10 @@ class IntEnumTest(unittest.TestCase):
         self.assertIsNot(self.Foo(1), self.Foo.baz)
 
 
-@mock.patch('spotify.search.lib', spec=spotify.lib)
+@mock.patch("spotify.search.lib", spec=spotify.lib)
 class SequenceTest(unittest.TestCase):
     def test_adds_ref_to_sp_obj_when_created(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         utils.Sequence(
             sp_obj=sp_search,
             add_ref_func=lib_mock.sp_search_add_ref,
@@ -191,7 +191,7 @@ class SequenceTest(unittest.TestCase):
         self.assertEqual(lib_mock.sp_search_add_ref.call_count, 1)
 
     def test_releases_sp_obj_when_sequence_dies(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         seq = utils.Sequence(
             sp_obj=sp_search,
             add_ref_func=lib_mock.sp_search_add_ref,
@@ -206,7 +206,7 @@ class SequenceTest(unittest.TestCase):
         self.assertEqual(lib_mock.sp_search_release.call_count, 1)
 
     def test_len_calls_len_func(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         len_func = mock.Mock()
         len_func.return_value = 0
         seq = utils.Sequence(
@@ -223,7 +223,7 @@ class SequenceTest(unittest.TestCase):
         len_func.assert_called_with(sp_search)
 
     def test_getitem_calls_getitem_func(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         getitem_func = mock.Mock()
         getitem_func.return_value = mock.sentinel.item_one
         seq = utils.Sequence(
@@ -240,7 +240,7 @@ class SequenceTest(unittest.TestCase):
         getitem_func.assert_called_with(sp_search, 0)
 
     def test_getitem_with_negative_index(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         getitem_func = mock.Mock()
         getitem_func.return_value = mock.sentinel.item_one
         seq = utils.Sequence(
@@ -257,7 +257,7 @@ class SequenceTest(unittest.TestCase):
         getitem_func.assert_called_with(sp_search, 0)
 
     def test_getitem_with_slice(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         getitem_func = mock.Mock()
         getitem_func.side_effect = [
             mock.sentinel.item_one,
@@ -284,7 +284,7 @@ class SequenceTest(unittest.TestCase):
         self.assertEqual(result[1], mock.sentinel.item_two)
 
     def test_getitem_raises_index_error_on_too_low_index(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         seq = utils.Sequence(
             sp_obj=sp_search,
             add_ref_func=lib_mock.sp_search_add_ref,
@@ -297,7 +297,7 @@ class SequenceTest(unittest.TestCase):
             seq[-3]
 
     def test_getitem_raises_index_error_on_too_high_index(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         seq = utils.Sequence(
             sp_obj=sp_search,
             add_ref_func=lib_mock.sp_search_add_ref,
@@ -310,7 +310,7 @@ class SequenceTest(unittest.TestCase):
             seq[1]
 
     def test_getitem_raises_type_error_on_non_integral_index(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         seq = utils.Sequence(
             sp_obj=sp_search,
             add_ref_func=lib_mock.sp_search_add_ref,
@@ -320,10 +320,10 @@ class SequenceTest(unittest.TestCase):
         )
 
         with self.assertRaises(TypeError):
-            seq['abc']
+            seq["abc"]
 
     def test_repr(self, lib_mock):
-        sp_search = spotify.ffi.cast('sp_search *', 42)
+        sp_search = spotify.ffi.cast("sp_search *", 42)
         seq = utils.Sequence(
             sp_obj=sp_search,
             add_ref_func=lib_mock.sp_search_add_ref,
@@ -334,19 +334,19 @@ class SequenceTest(unittest.TestCase):
 
         result = repr(seq)
 
-        self.assertEqual(result, 'Sequence([123])')
+        self.assertEqual(result, "Sequence([123])")
 
 
 class ToBytesTest(unittest.TestCase):
     def test_unicode_to_bytes_is_encoded_as_utf8(self):
-        self.assertEqual(utils.to_bytes('æøå'), 'æøå'.encode('utf-8'))
+        self.assertEqual(utils.to_bytes("æøå"), "æøå".encode("utf-8"))
 
     def test_bytes_to_bytes_is_passed_through(self):
-        self.assertEqual(utils.to_bytes('æøå'.encode('utf-8')), 'æøå'.encode('utf-8'))
+        self.assertEqual(utils.to_bytes("æøå".encode("utf-8")), "æøå".encode("utf-8"))
 
     def test_cdata_to_bytes_is_unwrapped(self):
-        cdata = spotify.ffi.new('char[]', 'æøå'.encode('utf-8'))
-        self.assertEqual(utils.to_bytes(cdata), 'æøå'.encode('utf-8'))
+        cdata = spotify.ffi.new("char[]", "æøå".encode("utf-8"))
+        self.assertEqual(utils.to_bytes(cdata), "æøå".encode("utf-8"))
 
     def test_anything_else_to_bytes_fails(self):
         with self.assertRaises(ValueError):
@@ -361,25 +361,25 @@ class ToBytesOrNoneTest(unittest.TestCase):
         self.assertEqual(utils.to_bytes_or_none(spotify.ffi.NULL), None)
 
     def test_char_becomes_bytes(self):
-        result = utils.to_bytes_or_none(spotify.ffi.new('char[]', b'abc'))
+        result = utils.to_bytes_or_none(spotify.ffi.new("char[]", b"abc"))
 
-        self.assertEqual(result, b'abc')
+        self.assertEqual(result, b"abc")
 
     def test_anything_else_fails(self):
         with self.assertRaises(ValueError):
-            utils.to_bytes_or_none(b'abc')
+            utils.to_bytes_or_none(b"abc")
 
 
 class ToUnicodeTest(unittest.TestCase):
     def test_unicode_to_unicode_is_passed_through(self):
-        self.assertEqual(utils.to_unicode('æøå'), 'æøå')
+        self.assertEqual(utils.to_unicode("æøå"), "æøå")
 
     def test_bytes_to_unicode_is_decoded_as_utf8(self):
-        self.assertEqual(utils.to_unicode('æøå'.encode('utf-8')), 'æøå')
+        self.assertEqual(utils.to_unicode("æøå".encode("utf-8")), "æøå")
 
     def test_cdata_to_unicode_is_unwrapped_and_decoded_as_utf8(self):
-        cdata = spotify.ffi.new('char[]', 'æøå'.encode('utf-8'))
-        self.assertEqual(utils.to_unicode(cdata), 'æøå')
+        cdata = spotify.ffi.new("char[]", "æøå".encode("utf-8"))
+        self.assertEqual(utils.to_unicode(cdata), "æøå")
 
     def test_anything_else_to_unicode_fails(self):
         with self.assertRaises(ValueError):
@@ -395,28 +395,28 @@ class ToUnicodeOrNoneTest(unittest.TestCase):
 
     def test_char_becomes_bytes(self):
         result = utils.to_unicode_or_none(
-            spotify.ffi.new('char[]', 'æøå'.encode('utf-8'))
+            spotify.ffi.new("char[]", "æøå".encode("utf-8"))
         )
 
-        self.assertEqual(result, 'æøå')
+        self.assertEqual(result, "æøå")
 
     def test_anything_else_fails(self):
         with self.assertRaises(ValueError):
-            utils.to_unicode_or_none('æøå')
+            utils.to_unicode_or_none("æøå")
 
 
 class ToCharTest(unittest.TestCase):
     def test_bytes_becomes_char(self):
-        result = utils.to_char(b'abc')
+        result = utils.to_char(b"abc")
 
         self.assertIsInstance(result, spotify.ffi.CData)
-        self.assertEqual(spotify.ffi.string(result), b'abc')
+        self.assertEqual(spotify.ffi.string(result), b"abc")
 
     def test_unicode_becomes_char(self):
-        result = utils.to_char('æøå')
+        result = utils.to_char("æøå")
 
         self.assertIsInstance(result, spotify.ffi.CData)
-        self.assertEqual(spotify.ffi.string(result).decode('utf-8'), 'æøå')
+        self.assertEqual(spotify.ffi.string(result).decode("utf-8"), "æøå")
 
     def test_anything_else_fails(self):
         with self.assertRaises(ValueError):
@@ -431,16 +431,16 @@ class ToCharOrNullTest(unittest.TestCase):
         self.assertEqual(utils.to_char_or_null(None), spotify.ffi.NULL)
 
     def test_bytes_becomes_char(self):
-        result = utils.to_char_or_null(b'abc')
+        result = utils.to_char_or_null(b"abc")
 
         self.assertIsInstance(result, spotify.ffi.CData)
-        self.assertEqual(spotify.ffi.string(result), b'abc')
+        self.assertEqual(spotify.ffi.string(result), b"abc")
 
     def test_unicode_becomes_char(self):
-        result = utils.to_char_or_null('æøå')
+        result = utils.to_char_or_null("æøå")
 
         self.assertIsInstance(result, spotify.ffi.CData)
-        self.assertEqual(spotify.ffi.string(result).decode('utf-8'), 'æøå')
+        self.assertEqual(spotify.ffi.string(result).decode("utf-8"), "æøå")
 
     def test_anything_else_fails(self):
         with self.assertRaises(ValueError):
@@ -449,23 +449,23 @@ class ToCharOrNullTest(unittest.TestCase):
 
 class ToCountryCodeTest(unittest.TestCase):
     def test_unicode_to_country_code(self):
-        self.assertEqual(utils.to_country_code('NO'), 20047)
-        self.assertEqual(utils.to_country_code('SE'), 21317)
+        self.assertEqual(utils.to_country_code("NO"), 20047)
+        self.assertEqual(utils.to_country_code("SE"), 21317)
 
     def test_bytes_to_country_code(self):
-        self.assertEqual(utils.to_country_code(b'NO'), 20047)
-        self.assertEqual(utils.to_country_code(b'SE'), 21317)
+        self.assertEqual(utils.to_country_code(b"NO"), 20047)
+        self.assertEqual(utils.to_country_code(b"SE"), 21317)
 
     def test_fails_if_not_exactly_two_chars(self):
         with self.assertRaises(ValueError):
-            utils.to_country_code('NOR')
+            utils.to_country_code("NOR")
 
     def test_fails_if_not_in_uppercase(self):
         with self.assertRaises(ValueError):
-            utils.to_country_code('no')
+            utils.to_country_code("no")
 
 
 class ToCountryTest(unittest.TestCase):
     def test_to_country(self):
-        self.assertEqual(utils.to_country(20047), 'NO')
-        self.assertEqual(utils.to_country(21317), 'SE')
+        self.assertEqual(utils.to_country(20047), "NO")
+        self.assertEqual(utils.to_country(21317), "SE")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,9 +5,8 @@ from __future__ import unicode_literals
 import unittest
 
 import spotify
-from spotify import utils
-
 import tests
+from spotify import utils
 from tests import mock
 
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,7 +6,6 @@ import unittest
 from distutils.version import StrictVersion as SV
 
 import spotify
-
 from tests import mock
 
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -27,9 +27,7 @@ class LibspotifyVersionTest(unittest.TestCase):
         self.assertEqual(result, 73)
 
     def test_libspotify_build_id(self, lib_mock):
-        build_id = spotify.ffi.new(
-            'char []', '12.1.51.foobaræøå'.encode('utf-8')
-        )
+        build_id = spotify.ffi.new('char []', '12.1.51.foobaræøå'.encode('utf-8'))
         lib_mock.sp_build_id.return_value = build_id
 
         result = spotify.get_libspotify_build_id()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -14,10 +14,10 @@ class VersionTest(unittest.TestCase):
         SV(spotify.__version__)
 
     def test_version_is_grater_than_all_1_x_versions(self):
-        self.assertLess(SV('1.999'), SV(spotify.__version__))
+        self.assertLess(SV("1.999"), SV(spotify.__version__))
 
 
-@mock.patch('spotify.version.lib', spec=spotify.lib)
+@mock.patch("spotify.version.lib", spec=spotify.lib)
 class LibspotifyVersionTest(unittest.TestCase):
     def test_libspotify_api_version(self, lib_mock):
         lib_mock.SPOTIFY_API_VERSION = 73
@@ -27,9 +27,9 @@ class LibspotifyVersionTest(unittest.TestCase):
         self.assertEqual(result, 73)
 
     def test_libspotify_build_id(self, lib_mock):
-        build_id = spotify.ffi.new('char []', '12.1.51.foobaræøå'.encode('utf-8'))
+        build_id = spotify.ffi.new("char []", "12.1.51.foobaræøå".encode("utf-8"))
         lib_mock.sp_build_id.return_value = build_id
 
         result = spotify.get_libspotify_build_id()
 
-        self.assertEqual(result, '12.1.51.foobaræøå')
+        self.assertEqual(result, "12.1.51.foobaræøå")

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py27, py35, py36, py37, py38, py39,
     pypy, pypy3,
-    black, check-manifest, docs, flake8
+    check-manifest, docs, flake8
 
 [testenv]
 # XXX For the tests to find the spotify._spotify module, we need to either:
@@ -16,10 +16,6 @@ commands =
         --cov=spotify --cov-report=term-missing \
         -v \
         {posargs}
-
-[testenv:black]
-deps = .[lint]
-commands = python -m black --check .
 
 [testenv:check-manifest]
 deps = .[lint]


### PR DESCRIPTION
- Replace flake8-import-order with flake8-isort
- Use Black's default line length
- Use Black's default string normalization
- Use flake8-black instead of linting with black directly
