### PR TITLE
docs: don't unwrap functions outside spotify module (Fixes #211)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ for mod_name, mod in vars(spotify).items():
     if not isinstance(mod, types.ModuleType) or mod_name in ("threading",):
         continue
     for cls in vars(mod).values():
-        if not isinstance(cls, type):
+        if not isinstance(cls, type) or not cls.__module__.startswith("spotify"):
             continue
         for method_name, method in vars(cls).items():
             if hasattr(method, "__wrapped__"):


### PR DESCRIPTION
Exposed when running under Python 3.10 due to 

> [bpo-43682](https://bugs.python.org/issue43682): Static methods ([@staticmethod](https://docs.python.org/3/library/functions.html#staticmethod)) and class methods ([@classmethod](https://docs.python.org/3/library/functions.html#classmethod)) now inherit the method attributes (module, name, qualname, doc, annotations) and have a new wrapped attribute. Patch by Victor Stinner.